### PR TITLE
add extract_implications.lean

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -22,6 +22,11 @@ rev = "main"
 [[lean_lib]]
 name = "equational_theories"
 
+[[lean_exe]]
+name = "extract_implications"
+root = "scripts.extract_implications"
+supportInterpreter = true
+
 [[require]]
 name = "egg"
 git  = "https://github.com/marcusrossel/lean-egg"

--- a/scripts/extract_implications.lean
+++ b/scripts/extract_implications.lean
@@ -1,0 +1,94 @@
+import Batteries.Data.String.Basic
+import Batteries.Tactic.Lint
+import Lean.Environment
+import Lean.Meta.Basic
+import Lean.Util
+
+open Lean Core Elab
+
+/--
+`lhs` implies `rhs`, where `lhs` and `rhs` are equation names for the form "Equation17".
+-/
+structure Implication where
+  lhs : String
+  rhs : String
+deriving Lean.ToJson, Lean.FromJson
+
+--- Output of the extract_implications executable.
+structure Output where
+  implications : List Implication
+  nonimplications : List Implication
+deriving Lean.ToJson, Lean.FromJson
+
+/--
+Extracts the equation name out of an expression of the form `EquationN G inst`.
+-/
+def getEquationName (app : Expr) : Option String := do
+  match app with
+  | (.app (.app (.const name _) _) _) => some ("" ++ name.toString)
+  | _ => none
+
+/--
+Extracts an `Implication` from two expressions of the form `EquationN G inst`.
+-/
+def implicationFromApps (lhs rhs : Expr) : Option Implication := do
+  let lhsName ← getEquationName lhs
+  let rhsName ← getEquationName rhs
+  return ⟨lhsName, rhsName⟩
+
+/--
+Attempts to parse an `Implication` from the type of a theorem.
+-/
+def parseImplication (thm_ty : Expr) : MetaM (Option Implication) := do
+  Meta.forallTelescope thm_ty fun fvars rhs => do
+    let #[_g, _magma, lhsv] := fvars | return none
+    -- TODO assert that g and magma have the expected types
+    let lhs ← Meta.inferType lhsv
+    return implicationFromApps lhs rhs
+
+/--
+Attempts to parse a negated `Implication` from the type of a theorem.
+-/
+def parseNonimplication (thm_ty : Expr) : MetaM (Option Implication) := do
+  match_expr thm_ty with
+  | Exists _ body =>
+    Meta.lambdaTelescope body fun _ ty => do
+      match_expr ty with
+      | Exists _ body1 =>
+        Meta.lambdaTelescope body1 fun _ ty1 => do
+          match_expr ty1 with
+          | And rhs b =>
+            match_expr b with
+            | Not lhs =>
+              return implicationFromApps lhs rhs
+            | _ => return none
+          | _ => return none
+
+      | _ => return none
+  | _ => return none
+
+unsafe def main (_args : List String) : IO Unit := do
+  let module := `equational_theories.Basic
+  searchPathRef.set compile_time_search_path%
+
+  let output : Output ← withImportModules #[{module}] {} (trustLevel := 1024) fun env =>
+    let ctx := {fileName := "", fileMap := default}
+    let state := {env}
+    Prod.fst <$> (Meta.MetaM.toIO · ctx state)  do
+      let decls ← Batteries.Tactic.Lint.getDeclsInPackage module
+      let mut implications : List Implication := []
+      let mut nonimplications : List Implication := []
+      for d in decls do
+        if not d.isInternal then
+          match ← getConstInfo d with
+          | .thmInfo thm =>
+            -- TODO check axioms for `sorry`
+            if let some imp ← parseImplication thm.type then
+              implications := imp :: implications
+            if let some nimp ← parseNonimplication thm.type then
+              nonimplications := nimp :: nonimplications
+            pure ()
+          | _ => pure ()
+      pure ⟨implications, nonimplications⟩
+
+  println! (Lean.toJson output).pretty

--- a/scripts/extract_implications.lean
+++ b/scripts/extract_implications.lean
@@ -74,7 +74,7 @@ def parseNonimplication (thm_ty : Expr) : MetaM (Option Implication) := do
   | _ => return none
 
 unsafe def main (_args : List String) : IO Unit := do
-  let module := `equational_theories.Basic
+  let module := `equational_theories.Subgraph
   searchPathRef.set compile_time_search_path%
 
   let output : Output ← withImportModules #[{module}] {} (trustLevel := 1024) fun env =>


### PR DESCRIPTION
This is a start on porting process_implications.py into Lean.

When I run this on the current repo via `lake exe extract_implications`, it outputs:

```console
{"nonimplications":
 [{"rhs": "Equation387", "lhs": "Equation4512"},
  {"rhs": "Equation43", "lhs": "Equation42"},
  {"rhs": "Equation3", "lhs": "Equation4512"},
  {"rhs": "Equation4512", "lhs": "Equation42"},
  {"rhs": "Equation4582", "lhs": "Equation43"},
  {"rhs": "Equation4582", "lhs": "Equation42"},
  {"rhs": "Equation3", "lhs": "Equation42"},
  {"rhs": "Equation4512", "lhs": "Equation4513"},
  {"rhs": "Equation43", "lhs": "Equation387"},
  {"rhs": "Equation4513", "lhs": "Equation4522"},
  {"rhs": "Equation4", "lhs": "Equation43"},
  {"rhs": "Equation46", "lhs": "Equation4"},
  {"rhs": "Equation43", "lhs": "Equation3"},
  {"rhs": "Equation46", "lhs": "Equation3"},
  {"rhs": "Equation43", "lhs": "Equation4512"},
  {"rhs": "Equation387", "lhs": "Equation42"},
  {"rhs": "Equation42", "lhs": "Equation4512"},
  {"rhs": "Equation42", "lhs": "Equation43"},
  {"rhs": "Equation4", "lhs": "Equation4582"}],
 "implications":
 [{"rhs": "Equation46", "lhs": "Equation2"},
  {"rhs": "Equation4513", "lhs": "Equation4522"},
  {"rhs": "Equation7", "lhs": "Equation2"},
  {"rhs": "Equation387", "lhs": "Equation46"},
  {"rhs": "Equation4512", "lhs": "Equation4513"},
  {"rhs": "Equation4", "lhs": "Equation2"},
  {"rhs": "Equation6", "lhs": "Equation2"},
  {"rhs": "Equation2", "lhs": "Equation7"},
  {"rhs": "Equation4522", "lhs": "Equation4"},
  {"rhs": "Equation43", "lhs": "Equation387"},
  {"rhs": "Equation3", "lhs": "Equation4"},
  {"rhs": "Equation42", "lhs": "Equation4"},
  {"rhs": "Equation41", "lhs": "Equation7"},
  {"rhs": "Equation4582", "lhs": "Equation46"},
  {"rhs": "Equation42", "lhs": "Equation46"},
  {"rhs": "Equation2", "lhs": "Equation6"},
  {"rhs": "Equation4522", "lhs": "Equation4582"}]}

```