### PR TITLE
Deep-embed graph

### DIFF
--- a/equational_theories/Equations.lean
+++ b/equational_theories/Equations.lean
@@ -2,44 +2,30 @@ import equational_theories.Magma
 import Mathlib.Tactic
 
 /- List of equational laws being studied -/
+inductive Equation: Type :=
+| e1 | e2 | e3 | e4 | e5 | e6 | e7 | e8 | e38 | e39
+| e40 | e41 | e42 | e43 | e46 | e168 | e387 | e4512 | e4513 | e4522 | e4582
 
-/-- The reflexive law -/
-def Equation1 (G: Type*) [Magma G] := ∀ x : G, x = x
-
-/-- The singleton law -/
-def Equation2 (G: Type*) [Magma G] := ∀ x y : G, x = y
-
-/-- The idempotence law -/
-def Equation3 (G: Type*) [Magma G] := ∀ x : G, x = x ∘ x
-
-/-- The left absorption law -/
-def Equation4 (G: Type*) [Magma G] := ∀ x y : G, x = x ∘ y
-
-/-- The right absorption law -/
-def Equation5 (G: Type*) [Magma G] := ∀ x y : G, x = y ∘ x
-
-@[inherit_doc Equation2]
-def Equation6 (G: Type*) [Magma G] := ∀ x y : G, x = y ∘ y
-
-@[inherit_doc Equation2]
-def Equation7 (G: Type*) [Magma G] := ∀ x y z : G, x = y ∘ z
-
-def Equation8 (G: Type*) [Magma G] := ∀ x : G, x = x ∘ (x ∘ x)
-
-/-- value of multiplication is independent of right argument -/
-def Equation38 (G: Type*) [Magma G] := ∀ x y : G, x ∘ x = x ∘ y
-
-/-- value of multiplication is independent of left argument; dual of 38 -/
-def Equation39 (G: Type*) [Magma G] := ∀ x y : G, x ∘ x = y ∘ x
-
-/-- all squares are the same -/
-def Equation40 (G: Type*) [Magma G] := ∀ x y : G, x ∘ x = y ∘ y
-
-/-- all products are the same -/
-def Equation41 (G: Type*) [Magma G] := ∀ x y z : G, x ∘ x = y ∘ z
-
-@[inherit_doc Equation38]
-def Equation42 (G: Type*) [Magma G] := ∀ x y z : G, x ∘ y = x ∘ z
+def Equation.interp (G: Type*) [Magma G] (e: Equation): Prop :=
+  match e with
+  /- The reflexive law -/
+  | .e1 => ∀ x : G, x = x
+  /- The singleton law -/
+  | .e2 => ∀ x y : G, x = y
+  | .e3 => ∀ x : G, x = x ∘ x
+  /- The left absorption law -/
+  | .e4 => ∀ x y : G, x = x ∘ y
+  /- The right absorption law -/
+  | .e5 => ∀ x y : G, x = y ∘ x
+  | .e6 => ∀ x y : G, x = y ∘ y
+  | .e7 => ∀ x y z : G, x = y ∘ z
+  | .e8 => ∀ x : G, x = x ∘ (x ∘ x)
+  | .e38 => ∀ x y : G, x ∘ x = x ∘ y
+  | .e39 => ∀ x y : G, x ∘ x = y ∘ x
+  | .e40 => ∀ x y : G, x ∘ x = y ∘ y
+  | .e41 => ∀ x y z : G, x ∘ x = y ∘ z
+  | .e42 => ∀ x y z : G, x ∘ y = x ∘ z
+  | _ => False
 
 /-- The commutative law -/
 def Equation43 (G: Type*) [Magma G] := ∀ x y : G, x ∘ y = y ∘ x


### PR DESCRIPTION
Hi all! Thank you for initiating this extremely exciting project.
This is my attempt to simplify & give more principled approach to maintain the implication graph.

[Syntactic data]
Each axiom (equation) is now has a concrete, syntactic term, named `Equation` type. A graph, `Graph` type, is defined as `Equation -> Equation -> Status` where `Status` denotes the current state for the corresponding edge. Then, a concrete instance for the subgraph is given as a term `subgraph: Graph`.

[Semantic interpretation]
The validity of this graph object is enforced with `Graph.valid` definition - e.g., `subgraph_valid` would be the final theorem for the subgraph. The `Graph.valid` requires corresponding semantic proof for each syntactic edges. Notably, `Edge` is defined with typeclass and has few benefits below.

Benefits are as follows:
- In my experience, it is easier to play with and less error-prone to write a deep-embed the object (graph here) rather than doing meta-programming to generate it later, which typically relies on specific naming schemes on string (e.g., `EquationX_implies_EquationY` should have the exact type `(G: Type*) [Magma G] (h: EquationX G) : EquationY G`, which could be error-prone.)
- Simplification: (1) the repeated `(G: Type*) [Magma G]` for each theorem is now omitted, and (2) we don't have to give explicit names to theorems thanks to typeclass mechanism. (e.g., `instance : (Edge true .e2 .e4) where` instead of `theorem Equation2_implies_Equation4 (G: Type*) [Magma G] (h: Equation2 G) : Equation4 G :=`)
- Edge Synthesis: see `Edge.trans_true`, `Edge.abduct_false0` and `Edge.abduct_false1`: the typeclass mechanism allows us to nicely derive some facts from existing facts. This is tested in the [code](https://github.com/teorth/equational_theories/compare/main...alxest:equational_theories:deepembed-graph#diff-401dfd7eb752f8b8b969d15d6b990a698efe1fe63ea7d864282233b0a041693fR425-R430).

Surely, all these could be implemented manually, but it would be good to piggyback on existing language features in the start, until we reach the point that it doesn't scale. If you find this useful, I can make it a mergeable state quickly.
