### PR TITLE
replace `proof_wanted` by a new `conjecture` command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ In addition to these files, contributors are welcome to add additional Lean file
 - The standard form for an implication "Equation X implies Equation Y" is
 `theorem EquationX_implies_EquationY (G: Type*) [Magma G] (h: EquationX G) : EquationY G`
 - The standard form for an anti-implication "Equation X does not imply Equation Y" is `theorem EquationX_not_implies_EquationY : ∃ (G: Type) (_: Magma G), EquationX G ∧ ¬ EquationY G`.
-- You are also encouraged to add `proof_wanted` versions of these theorems, for results that were obtained by hand or by some other automated tool whose output is not in the form of a Lean proof.  If you are creating such `proof_wanted` statements, consider adding a sketch of the proof as a comment in the Lean file.  We can then add tasks (via Github issues) to convert such `proof_wanted` statements into theorems.  (Technical note: to avoid linter warnings, one can replace `h: EquationX G` with `_: EquationX G` in a `proof_wanted` implication.)
+- You are also encouraged to add `conjecture` versions of these theorems, for results that were obtained by hand or by some other automated tool whose output is not in the form of a Lean proof.  If you are creating such `conjecture` statements, consider adding a sketch of the proof as a comment in the Lean file.  We can then add tasks (via Github issues) to convert such `conjecture` statements into theorems.  (Technical note: to avoid linter warnings, one can replace `h: EquationX G` with `_: EquationX G` in a `conjecture` implication.)
 - To establish an equivalence between two Equations X and Y, split it into two implications "Equation X implies Equation Y" and "Equation Y implies Equation X" as above.
 - To avoid collisions, implications and anti-implications should be placed inside a namespace specific to your Lean file.
 - Consider adding a chapter to the blueprint corresponding to the Lean file, which can for instance detail the methodology used to generate the content of that file.
@@ -63,7 +63,7 @@ Contributions in programming languages other than Lean are very welcome; the cod
 
 ## Data
 
-Output from code that is not Lean proofs (or `proof_wanted` claims in Lean) can be placed in the [data directory](data).
+Output from code that is not Lean proofs (or `conjecture` claims in Lean) can be placed in the [data directory](data).
 
 ## Automated Proofs
 

--- a/equational_theories/Conjecture.lean
+++ b/equational_theories/Conjecture.lean
@@ -1,0 +1,87 @@
+import Lean.Elab.Exception
+import Lean.Elab.Declaration
+
+import equational_theories.ParseImplications
+
+open Lean Parser Elab Command
+
+namespace Conjecture
+
+/--
+Like `proof_wanted` from Batteries, but records the conjecture in an
+environment extension.
+-/
+@[command_parser]
+def «conjecture» := leading_parser
+  declModifiers false >> "conjecture" >> declId >> ppIndent declSig
+
+/-- An entry in the conjecture environment extension.
+-/
+inductive EntryVariant where
+  | implication : Implication → EntryVariant
+  | nonimplication : Implication → EntryVariant
+  | other : EntryVariant
+
+/-- An entry in the conjecture environment extension -/
+structure Entry where
+/-- Name of the declaration. -/
+(name : Name)
+/-- Lean code to be included in the extracted problem file. -/
+(variant : EntryVariant)
+
+initialize conjectureExtension : SimplePersistentEnvExtension Entry (Array Entry) ←
+  registerSimplePersistentEnvExtension {
+    name := `conjecture
+    addImportedFn := Array.concatMap id
+    addEntryFn    := Array.push
+  }
+
+/-- Elaborates a `conjecture` declaration. The declaration is translated to an axiom during
+elaboration, but it's then removed from the environment.
+-/
+@[command_elab «conjecture»]
+def elabConjecture : CommandElab
+  | `($mods:declModifiers conjecture $name $args* : $res) => do
+    let maybe_entry ← withoutModifyingEnv do
+      let modifiers ← elabModifiers mods
+      let expanded_decl_id ← expandDeclId name modifiers
+
+      -- The helper axiom is used instead of `sorry` to avoid spurious warnings
+      elabDeclaration <| ← `(command| axiom helper (p : Prop) : p)
+      elabDeclaration <| ← `(command| $mods:declModifiers
+                                      theorem $name $args* : $res := helper _)
+
+      match ← getConstInfo expanded_decl_id.declName with
+      | .thmInfo  (val : TheoremVal) =>
+        liftCoreM <| Meta.MetaM.run' do
+        if let some imp ← parseImplication val.type then
+          return some ⟨val.name, .implication imp⟩
+        if let some nimp ← parseNonimplication val.type then
+          return some ⟨val.name, .nonimplication nimp⟩
+        return some ⟨val.name, .other⟩
+      | _ => pure none
+
+    if let some entry := maybe_entry then
+      modifyEnv fun env =>
+        conjectureExtension.addEntry env entry
+    pure ()
+  | _ => throwUnsupportedSyntax
+
+/-- Returns the contents of the conjecture environment extension.
+-/
+def extractConjectures {m : Type → Type} [Monad m] [MonadEnv m] [MonadError m] :
+    m (Array Entry) := do
+  return conjectureExtension.getState (← getEnv)
+
+/-- Prints the contents of the conjecture environment extension.
+-/
+syntax (name := printConjectures) "#print_conjectures" : command
+
+elab_rules : command
+| `(command| #print_conjectures) => do
+  let cs ← extractConjectures
+  for ⟨name, conj⟩ in cs do
+    match conj with
+    | .implication ⟨lhs, rhs⟩ => println! "{name}: {lhs} → {rhs}"
+    | .nonimplication ⟨lhs, rhs⟩ => println! "{name}: ¬ ({lhs} → {rhs})"
+    | _ => println! "{name}"

--- a/equational_theories/Subgraph.lean
+++ b/equational_theories/Subgraph.lean
@@ -1,6 +1,6 @@
 import Mathlib.Tactic
 import Mathlib.Data.Nat.Defs
-import Batteries.Util.ProofWanted
+import equational_theories.Conjecture
 import equational_theories.Equations
 
 /- This is a subproject of the main project to completely describe a small subgraph of the entire
@@ -121,7 +121,7 @@ theorem Equation7_implies_Equation41 (G: Type*) [Magma G] (h: Equation7 G) : Equ
 theorem Equation38_implies_Equation42 (G: Type*) [Magma G] (h: Equation38 G) : Equation42 G :=
   fun _ _ _ ↦ by rw [← h, h]
 
-proof_wanted Equation39_implies_Equation45 (G: Type*) [Magma G] (h: Equation39 G) : Equation45 G
+conjecture Equation39_implies_Equation45 (G: Type*) [Magma G] (_h: Equation39 G) : Equation45 G
 
 theorem Equation41_implies_Equation40 (G: Type*) [Magma G] (h: Equation41 G) : Equation40 G :=
   fun _ _ ↦ by rw [h]
@@ -132,7 +132,7 @@ theorem Equation41_implies_Equation46 (G: Type*) [Magma G] (h: Equation41 G) : E
 theorem Equation42_implies_Equation38 (G: Type*) [Magma G] (h: Equation42 G) : Equation38 G :=
   fun _ _ ↦ by rw [h]
 
-proof_wanted Equation45_implies_Equation39 (G: Type*) [Magma G] (h: Equation45 G) : Equation39 G
+conjecture Equation45_implies_Equation39 (G: Type*) [Magma G] (_h: Equation45 G) : Equation39 G
 
 theorem Equation46_implies_Equation40 (G: Type*) [Magma G] (h: Equation46 G) : Equation40 G :=
   fun x y ↦ h x x y y


### PR DESCRIPTION
The new command records all conjectures to enable later analysis.

Additionally adds a `#print_conjectures` command for showing the current set of conjectures.

The current output of `#print_conjectures` if added at the bottom of `Subgraph.lean` is:
```
Subgraph.Equation39_implies_Equation45: Equation39 → Equation45
Subgraph.Equation45_implies_Equation39: Equation45 → Equation39

```