### PR TITLE
added an initial attempt at treating magma words as syntactic objects to facilitate proving metatheorems

### DIFF
--- a/equational_theories/FreeMagma.lean
+++ b/equational_theories/FreeMagma.lean
@@ -1,0 +1,43 @@
+import equational_theories.Conjecture
+import equational_theories.AllEquations
+
+universe u
+universe v
+
+inductive FreeMagma (α : Type u)
+  | Leaf : α → FreeMagma α
+  | Fork : FreeMagma α → FreeMagma α → FreeMagma α
+
+infixl:65 " ⋆ " => FreeMagma.Fork
+def Lf {α : Type u} : (α → FreeMagma α) := FreeMagma.Leaf
+
+def fmapFreeMagma {α : Type u} {β : Type v} (f : α → β) : FreeMagma α → FreeMagma β
+  | FreeMagma.Leaf a => FreeMagma.Leaf (f a)
+  | FreeMagma.Fork lchild rchild => FreeMagma.Fork (fmapFreeMagma f lchild) (fmapFreeMagma f rchild)
+
+def evalInMagma {α : Type u} {G : Type v} [Magma G] (f : α -> G) : FreeMagma α → G
+  | FreeMagma.Leaf a => f a
+  | FreeMagma.Fork lchild rchild => (evalInMagma f lchild) ∘ (evalInMagma f rchild)
+
+theorem ExpressionEqualsAnything_implies_Equation2 (G: Type u) [Magma G]
+  : (∃ n : Nat, ∃ expr : FreeMagma (Fin n), ∀ x : G, ∀ sub : Fin n → G, x = evalInMagma sub expr) → Equation2 G := by
+  intros ex x y
+  let ⟨n, expr, univ⟩ := ex
+  let constx : Fin n → G := fun _ ↦ x
+  exact (Eq.trans (univ x constx) (Eq.symm (univ y constx)))
+
+theorem Equation37_implies_Equation2 (G : Type u) [Magma G]
+  : (∀ x y z w : G, x = (y ∘ z) ∘ w) → Equation2 G :=
+  fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
+    3,
+    (Lf 0 ⋆ Lf 1) ⋆ Lf 2, -- The syntactic representation of (y ∘ z) ∘ w
+    fun k sub ↦ univ k (sub 0) (sub 1) (sub 2)
+  ⟩
+
+theorem Equation514_implies_Equation2 (G : Type u) [Magma G]
+  : (∀ x y : G, x = y ∘ (y ∘ (y ∘ y))) → Equation2 G :=
+  fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
+    1,
+    Lf 0 ⋆ (Lf 0 ⋆ (Lf 0 ⋆ Lf 0)), -- The syntactic representation of y ∘ (y ∘ (y ∘ y)))
+    fun k sub ↦ univ k (sub 0)
+  ⟩


### PR DESCRIPTION
The inductive type `FreeMagma` implements abstract syntax trees over the magma operation (i.e. just binary trees), with the leaves indexed by a given type. This lets us express magma words like `(y ∘ z) ∘ w)` as tree data structures `(Lf 0 ⋆ Lf 1) ⋆ Lf 2`. The function `evalInMagma` evaluates the syntax tree in a certain magma of choice, for a given specialization of the leaf values.

Included is an example of a "metatheorem" saying roughly that whenever a universal identity of the form `x0 = f(x1,x2,...)` holds, then the universal identity `x = y` holds. It is applied to prove both `Equation37 -> Equation2` and `Equation514 -> Equation2`.

This approach is a bit wanting for syntactic sugar, but it could be a start!