### PR TITLE
Make `FreeMagma` a Magma

### DIFF
--- a/equational_theories/FreeMagma.lean
+++ b/equational_theories/FreeMagma.lean
@@ -11,15 +11,21 @@ inductive FreeMagma (α : Type u)
 instance (α : Type u) : Magma (FreeMagma α) where
   op := FreeMagma.Fork
 
-def Lf {α : Type u} : α → FreeMagma α := FreeMagma.Leaf
+infixl:65 " ⋆ " => FreeMagma.Fork
+
+@[simp]
+theorem FreeMagma_op_eq_fork (α : Type u) (a b : FreeMagma α) : a ∘ b = a ⋆ b := rfl
+
+@[match_pattern]
+def Lf {α : Type u} : (α → FreeMagma α) := FreeMagma.Leaf
 
 def fmapFreeMagma {α : Type u} {β : Type v} (f : α → β) : FreeMagma α → FreeMagma β
-  | FreeMagma.Leaf a => FreeMagma.Leaf (f a)
-  | FreeMagma.Fork lchild rchild => FreeMagma.Fork (fmapFreeMagma f lchild) (fmapFreeMagma f rchild)
+  | Lf a => FreeMagma.Leaf (f a)
+  | lchild ⋆ rchild => FreeMagma.Fork (fmapFreeMagma f lchild) (fmapFreeMagma f rchild)
 
 def evalInMagma {α : Type u} {G : Type v} [Magma G] (f : α -> G) : FreeMagma α → G
-  | FreeMagma.Leaf a => f a
-  | FreeMagma.Fork lchild rchild => (evalInMagma f lchild) ∘ (evalInMagma f rchild)
+  | Lf a => f a
+  | lchild ⋆ rchild => (evalInMagma f lchild) ∘ (evalInMagma f rchild)
 
 theorem ExpressionEqualsAnything_implies_Equation2 (G: Type u) [Magma G]
   : (∃ n : Nat, ∃ expr : FreeMagma (Fin n), ∀ x : G, ∀ sub : Fin n → G, x = evalInMagma sub expr) → Equation2 G := by
@@ -32,7 +38,7 @@ theorem Equation37_implies_Equation2 (G : Type u) [Magma G]
   : (∀ x y z w : G, x = (y ∘ z) ∘ w) → Equation2 G :=
   fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
     3,
-    (Lf 0 ∘ Lf 1) ∘ Lf 2, -- The syntactic representation of (y ∘ z) ∘ w
+    (Lf 0 ⋆ Lf 1) ⋆ Lf 2, -- The syntactic representation of (y ∘ z) ∘ w
     fun k sub ↦ univ k (sub 0) (sub 1) (sub 2)
   ⟩
 
@@ -40,6 +46,6 @@ theorem Equation514_implies_Equation2 (G : Type u) [Magma G]
   : (∀ x y : G, x = y ∘ (y ∘ (y ∘ y))) → Equation2 G :=
   fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
     1,
-    Lf 0 ∘ (Lf 0 ∘ (Lf 0 ∘ Lf 0)), -- The syntactic representation of y ∘ (y ∘ (y ∘ y)))
+    Lf 0 ⋆ (Lf 0 ⋆ (Lf 0 ⋆ Lf 0)), -- The syntactic representation of y ∘ (y ∘ (y ∘ y)))
     fun k sub ↦ univ k (sub 0)
   ⟩

--- a/equational_theories/FreeMagma.lean
+++ b/equational_theories/FreeMagma.lean
@@ -8,8 +8,10 @@ inductive FreeMagma (α : Type u)
   | Leaf : α → FreeMagma α
   | Fork : FreeMagma α → FreeMagma α → FreeMagma α
 
-infixl:65 " ⋆ " => FreeMagma.Fork
-def Lf {α : Type u} : (α → FreeMagma α) := FreeMagma.Leaf
+instance (α : Type u) : Magma (FreeMagma α) where
+  op := FreeMagma.Fork
+
+def Lf {α : Type u} : α → FreeMagma α := FreeMagma.Leaf
 
 def fmapFreeMagma {α : Type u} {β : Type v} (f : α → β) : FreeMagma α → FreeMagma β
   | FreeMagma.Leaf a => FreeMagma.Leaf (f a)
@@ -30,7 +32,7 @@ theorem Equation37_implies_Equation2 (G : Type u) [Magma G]
   : (∀ x y z w : G, x = (y ∘ z) ∘ w) → Equation2 G :=
   fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
     3,
-    (Lf 0 ⋆ Lf 1) ⋆ Lf 2, -- The syntactic representation of (y ∘ z) ∘ w
+    (Lf 0 ∘ Lf 1) ∘ Lf 2, -- The syntactic representation of (y ∘ z) ∘ w
     fun k sub ↦ univ k (sub 0) (sub 1) (sub 2)
   ⟩
 
@@ -38,6 +40,6 @@ theorem Equation514_implies_Equation2 (G : Type u) [Magma G]
   : (∀ x y : G, x = y ∘ (y ∘ (y ∘ y))) → Equation2 G :=
   fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
     1,
-    Lf 0 ⋆ (Lf 0 ⋆ (Lf 0 ⋆ Lf 0)), -- The syntactic representation of y ∘ (y ∘ (y ∘ y)))
+    Lf 0 ∘ (Lf 0 ∘ (Lf 0 ∘ Lf 0)), -- The syntactic representation of y ∘ (y ∘ (y ∘ y)))
     fun k sub ↦ univ k (sub 0)
   ⟩


### PR DESCRIPTION
Also adds the simp lemma `FreeMagma_op_eq_fork`, which makes the normal form `a ⋆ b`, which is better because it's a constructor application so we can use it in pattern matching

Closes #119