### PR TITLE
add comment explaining why string is copied in getEquationName

### DIFF
--- a/equational_theories/ParseImplications.lean
+++ b/equational_theories/ParseImplications.lean
@@ -29,7 +29,10 @@ Extracts the equation name out of an expression of the form `EquationN G inst`.
 -/
 def getEquationName (app : Expr) : Option String := do
   match app with
-  | (.app (.app (.const name _) _) _) => some ("" ++ name.toString)
+  | (.app (.app (.const name _) _) _) =>
+    -- Copy the string to allow it to safely escape from `Lean.withImportModules`.
+    -- Otherwise, segfaults are possible.
+    some ("" ++ name.toString)
   | _ => none
 
 /--


### PR DESCRIPTION
When I first added this code, the odd-looking `"" ++ name.toString` was necessary to prevent a crash in `extract_implications`.

See the [doc comment on `withImportModules`](https://github.com/leanprover/lean4/blob/ddec5336e505130bd60949744d31c828660928ef/src/Lean/Environment.lean#L921-L922).

Now that `extract_implications` has been restructured and does all of its logic withing the `withImportModules` scope, the crash is not an immediate danger, but I still think it's prudent to keep the copying in for future-proofing.

Hence this PR adds a comment to explain why the copying is there.
