### PR TITLE
Add 'raw' subcommand to extract_implications to provide output for other scripts

### DIFF
--- a/equational_theories/Closure.lean
+++ b/equational_theories/Closure.lean
@@ -296,10 +296,9 @@ def closure (inp : Array EntryVariant) : Array Edge := Id.run do
 
   pure ans
 
-def list_outcomes {m : Type → Type} [Monad m] [MonadEnv m] [MonadError m] :
-    m (Array String × Array (Array Outcome)) := do
-  let rs := (← Result.extractEquationalResults).map (·.variant)
-  let prs := ((← Result.extractTheorems).map (·.variant))
+def list_outcomes (res : Array Entry) : Array String × Array (Array Outcome) := Id.run do
+  let rs := res.map (·.variant)
+  let prs := res.filter (·.proven) |>.map (·.variant)
   let (eqs, eqs_order) := number_equations rs
   let n := eqs.size
   let mut outcomes : Array (Array Outcome) := Array.mkArray n (Array.mkArray n .unknown)

--- a/scripts/extract_implications.lean
+++ b/scripts/extract_implications.lean
@@ -11,7 +11,7 @@ def withExtractedResults (imp : Cli.Parsed) (action : Array Entry → IO UInt32)
     imp.printHelp
     return 1
   if modules.isEmpty then
-    modules := #[(ParseableType.parse? "equational_theories").get!]
+    modules := #[`equational_theories]
   searchPathRef.set compile_time_search_path%
 
   unsafe withImportModules (modules.map ({module := ·})) {} (trustLevel := 1024) fun env =>


### PR DESCRIPTION
Ideally we should do all out processing in Lean - single codebase, optimizing compiler.

But for now IMO we should have the ability to run the existing scripts.