### PR TITLE
add generate_dashboard.py and invoke it in CI

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -108,6 +108,11 @@ jobs:
           find home_page/docs -name "*.trace" -delete
           find home_page/docs -name "*.hash" -delete
 
+      - name: Generate home_page/dashboard.md
+        run: |
+          ~/.elan/bin/lake exe extract_implications outcomes equational_theories --hist > /tmp/hist.json
+          python scripts/generate_dashboard.py /tmp/hist.json
+
       - name: Bundle dependencies
         if: github.event_name == 'push'
         uses: ruby/setup-ruby@v1

--- a/scripts/extract_implications.lean
+++ b/scripts/extract_implications.lean
@@ -77,9 +77,12 @@ def generateOutcomes (inp : Cli.Parsed) : IO UInt32 := do
         for b in a do
           count := count.insert b (count.getD b 0 + 1)
       IO.print "{"
+      let mut first := true
       for ⟨a, b⟩ in count do
-        println! "{a}: {b},"
-      IO.println "}"
+        if !first then IO.print ",\n"
+        IO.print f!"{a}: {b}"
+        first := false
+      IO.println "\n}"
     else
       IO.println (toJson ({equations, outcomes : OutputOutcomes})).compress
     pure 0

--- a/scripts/generate_dashboard.py
+++ b/scripts/generate_dashboard.py
@@ -1,0 +1,35 @@
+import argparse
+import json
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="generate the dashboard markdown")
+    parser.add_argument("hist_file",
+                        help="json file containing output of `lake exe extract_implications outcomes --hist")
+    parser.add_argument("--out_file",
+                        default="home_page/dashboard.md",
+                        help="markdown file to pass to jekyll")
+
+    args = parser.parse_args()
+    with open(args.hist_file, 'r') as f:
+        data = json.load(f)
+
+    explicit_proof_true = data['explicit_proof_true']
+    implicit_proof_true = data['implicit_proof_true']
+    explicit_proof_false = data['explicit_proof_false']
+    implicit_proof_false = data['implicit_proof_false']
+    unknown = data['unknown'];
+    known_total = explicit_proof_true + implicit_proof_true + explicit_proof_false + implicit_proof_false
+    total = known_total + unknown
+
+    outfile = open(args.out_file, 'w')
+    outfile.write("\n")
+    outfile.write("Implication counts (see [this github issue](https://github.com/teorth/equational_theories/issues/29) for an explanation):\n\n")
+    outfile.write("| explicitly true | implicitly true | explicitly false | implicitly false | unknown |\n")
+    outfile.write("| -- | -- | -- | -- | -- |\n")
+    outfile.write("| {} | {} | {} | {} | {} |\n".format(
+        explicit_proof_true, implicit_proof_true, explicit_proof_false,
+        implicit_proof_false, unknown))
+    outfile.write("\n")
+    ratio = known_total / total
+    outfile.write(f"**{ratio:.3%}** complete")
+


### PR DESCRIPTION
Adds a minimal dashboard page to the website. This is mainly a proof of concept. The idea is to add a bunch more stuff in later PRs.

![Screenshot from 2024-10-02 14-05-00](https://github.com/user-attachments/assets/c077a03c-7d46-481d-8712-9c8944d56adf)
