### PR TITLE
Proved several implications from Equation1571

### DIFF
--- a/equational_theories/AllEquations.lean
+++ b/equational_theories/AllEquations.lean
@@ -34,7 +34,7 @@ equation 12 := x = x ∘ (y ∘ z)
 equation 13 := x = y ∘ (x ∘ x)
 -- equation 14 := x = y ∘ (x ∘ y)
 equation 15 := x = y ∘ (x ∘ z)
-equation 16 := x = y ∘ (y ∘ x)
+-- equation 16 := x = y ∘ (y ∘ x)
 equation 17 := x = y ∘ (y ∘ y)
 equation 18 := x = y ∘ (y ∘ z)
 equation 19 := x = y ∘ (z ∘ x)
@@ -1589,7 +1589,7 @@ equation 1567 := x = (y ∘ z) ∘ (x ∘ (w ∘ w))
 equation 1568 := x = (y ∘ z) ∘ (x ∘ (w ∘ u))
 equation 1569 := x = (y ∘ z) ∘ (y ∘ (x ∘ x))
 equation 1570 := x = (y ∘ z) ∘ (y ∘ (x ∘ y))
-equation 1571 := x = (y ∘ z) ∘ (y ∘ (x ∘ z))
+-- equation 1571 := x = (y ∘ z) ∘ (y ∘ (x ∘ z))
 equation 1572 := x = (y ∘ z) ∘ (y ∘ (x ∘ w))
 equation 1573 := x = (y ∘ z) ∘ (y ∘ (y ∘ x))
 equation 1574 := x = (y ∘ z) ∘ (y ∘ (y ∘ y))
@@ -2680,7 +2680,7 @@ equation 2658 := x = ((x ∘ x) ∘ (y ∘ z)) ∘ w
 equation 2659 := x = ((x ∘ y) ∘ (x ∘ x)) ∘ x
 equation 2660 := x = ((x ∘ y) ∘ (x ∘ x)) ∘ y
 equation 2661 := x = ((x ∘ y) ∘ (x ∘ x)) ∘ z
-equation 2662 := x = ((x ∘ y) ∘ (x ∘ y)) ∘ x
+-- equation 2662 := x = ((x ∘ y) ∘ (x ∘ y)) ∘ x
 equation 2663 := x = ((x ∘ y) ∘ (x ∘ y)) ∘ y
 equation 2664 := x = ((x ∘ y) ∘ (x ∘ y)) ∘ z
 equation 2665 := x = ((x ∘ y) ∘ (x ∘ z)) ∘ x

--- a/equational_theories/Equations.lean
+++ b/equational_theories/Equations.lean
@@ -37,13 +37,15 @@ abbrev Equation7 (G: Type _) [Magma G] := ∀ x y z : G, x = y ∘ z
 abbrev Equation8 (G: Type _) [Magma G] := ∀ x : G, x = x ∘ (x ∘ x)
 
 /-- Appears in Problem A1 from Putnam 2001 -/
-abbrev Equation14 (G : Type _) [Magma G] := ∀ x y : G, x = y ∘ (x ∘ y)
+abbrev Equation14 (G: Type _) [Magma G] := ∀ x y : G, x = y ∘ (x ∘ y)
+
+abbrev Equation16 (G: Type _) [Magma G] := ∀ x y : G, x = y ∘ (y ∘ x)
 
 /-- dual of 8 -/
 abbrev Equation23 (G: Type _) [Magma G] := ∀ x : G, x = (x ∘ x) ∘ x
 
 /-- Appears in Problem A1 from Putnam 2001.  Dual of 14 -/
-abbrev Equation29 (G : Type _) [Magma G] := ∀ x y : G, x = (y ∘ x) ∘ y
+abbrev Equation29 (G: Type _) [Magma G] := ∀ x y : G, x = (y ∘ x) ∘ y
 
 /-- value of multiplication is independent of right argument -/
 abbrev Equation38 (G: Type _) [Magma G] := ∀ x y : G, x ∘ x = x ∘ y
@@ -78,14 +80,21 @@ abbrev Equation381 (G: Type _) [Magma G] := ∀ x y z : G, x ∘ y = (x ∘ z) �
 /-- from the mathoverflow post by paste bee -/
 abbrev Equation387 (G: Type _) [Magma G] := ∀ x y : G, x ∘ y = (y ∘ y) ∘ x
 
+/-- From a paper of Mendelsohn & Padmanabhan, this law axiomatizes abelian groups of exponent 2 -/
+abbrev Equation1571 (G: Type _) [Magma G] := ∀ x y z : G, x = (y ∘ z) ∘ (y ∘ (x ∘ z))
+-- x = (y ∘ z) ∘ (y ∘ (x ∘ z))
+-- x =
+
 /-- From a paper of Kisielewicz -/
 abbrev Equation1689 (G: Type _) [Magma G] := ∀ x y z : G, x = (y ∘ x) ∘ ((x ∘ z) ∘ z)
 
+abbrev Equation2662 (G: Type _) [Magma G] := ∀ x y : G, x = ((x ∘ y) ∘ (x ∘ y)) ∘ x
+
 /-- From Putnam 1978, Problem A4, part (a) -/
-abbrev Equation3722 (G : Type _) [Magma G] := ∀ x y : G, x ∘ y = (x ∘ y) ∘ (x ∘ y)
+abbrev Equation3722 (G: Type _) [Magma G] := ∀ x y : G, x ∘ y = (x ∘ y) ∘ (x ∘ y)
 
 /-- Putnam 1978, Problem A4 calls this a "bypass operation" -/
-abbrev Equation3744 (G : Type _) [Magma G] := ∀ x y z w : G, x ∘ y = (x ∘ z) ∘ (w ∘ y)
+abbrev Equation3744 (G: Type _) [Magma G] := ∀ x y z w : G, x ∘ y = (x ∘ z) ∘ (w ∘ y)
 
 /-- The associative law -/
 abbrev Equation4512 (G: Type _) [Magma G] := ∀ x y z : G, x ∘ (y ∘ z) = (x ∘ y) ∘ z

--- a/equational_theories/Subgraph.lean
+++ b/equational_theories/Subgraph.lean
@@ -335,6 +335,14 @@ theorem Equation1571_implies_Equation43 (G: Type*) [Magma G] (h: Equation1571 G)
   apply Eq.trans $ h _ (x ∘ x) (x ∘ (x ∘ y))
   rw [← h x x y, ← eq23 x, ← eq16 y x, eq40 x y, ← eq23 y]
 
+@[equational_result]
+theorem Equation1571_implies_Equation4512 (G: Type*) [Magma G] (h: Equation1571 G) : Equation4512 G := by
+  have eq16 := Equation1571_implies_Equation16 G h
+  have eq43 := Equation1571_implies_Equation43 G h
+  intro x y z
+  apply Eq.trans $ h (x ∘ (y ∘ z)) y x
+  rw [eq43 (x ∘ (y ∘ z)) x, ← eq16 (y ∘ z) x, ← eq16 z y, eq43 y x]
+
 /-- This result was first obtained by Kisielewicz in 1997 via computer assistance. -/
 @[equational_result]
 theorem Equation1689_implies_Equation2 (G: Type*) [Magma G] (h: Equation1689 G) : Equation2 G:= by

--- a/equational_theories/Subgraph.lean
+++ b/equational_theories/Subgraph.lean
@@ -281,6 +281,60 @@ theorem Lemma_eq1689_implies_h8 (G: Type*) [Magma G] (h: Equation1689 G) : ∀ a
     _ = (a ∘ b) ∘ ((b ∘ c) ∘ c) := by rw [Lemma_eq1689_implies_h5 G h]
     _ = b := by rw [← h]
 
+/-- The below results for Equation1571 are out of order because early ones are lemmas for later ones -/
+@[equational_result]
+theorem Equation1571_implies_Equation2662 (G: Type*) [Magma G] (h: Equation1571 G) : Equation2662 G :=
+  fun x y ↦ Eq.trans (h x (x ∘ y) (x ∘ y)) (congrArg (fun z ↦ ((x ∘ y) ∘ (x ∘ y)) ∘ z) (Eq.symm $ h x x y))
+
+@[equational_result]
+theorem Equation1571_implies_Equation40 (G: Type*) [Magma G] (h: Equation1571 G) : Equation40 G := by
+  have eq2662 := Equation1571_implies_Equation2662 G h
+  have sqRotate : ∀ x y z : G, (x ∘ y) ∘ (x ∘ y) = (y ∘ z) ∘ (y ∘ z)
+    := fun x y z ↦ Eq.trans (congrArg (fun w ↦ (x ∘ y) ∘ (x ∘ w)) (eq2662 y z)) (Eq.symm $ h ((y ∘ z) ∘ (y ∘ z)) x y)
+  have sqConstInImage : ∀ x y z w : G, (x ∘ y) ∘ (x ∘ y) = (z ∘ w) ∘ (z ∘ w)
+    := fun x y z w ↦ Eq.trans (sqRotate x y z) (sqRotate y z w)
+  intro x y
+  rw [h x x x, h y y y]
+  exact sqConstInImage (x ∘ x) (x ∘ (x ∘ x)) (y ∘ y) (y ∘ (y ∘ y))
+
+@[equational_result]
+theorem Equation1571_implies_Equation23 (G: Type*) [Magma G] (h: Equation1571 G) : Equation23 G := by
+  have eq40 := Equation1571_implies_Equation40 G h
+  intro x
+  apply Eq.trans $ h x (x ∘ x) (x ∘ x)
+  rw [← h x x x]
+  rw [← eq40 x (x ∘ x)]
+
+@[equational_result]
+theorem Equation1571_implies_Equation8 (G: Type*) [Magma G] (h: Equation1571 G) : Equation8 G := by
+  have eq23 := Equation1571_implies_Equation23 G h
+  have eq40 := Equation1571_implies_Equation40 G h
+  intro x
+  apply Eq.trans $ h x x x
+  apply Eq.trans $ congrArg (fun a ↦ a ∘ (x ∘ (x ∘ x))) (eq40 x (x ∘ (x ∘ x)))
+  apply Eq.trans $ Eq.symm $ eq23 (x ∘ (x ∘ x))
+  apply refl _
+
+@[equational_result]
+theorem Equation1571_implies_Equation16 (G: Type*) [Magma G] (h: Equation1571 G) : Equation16 G := by
+  have eq8 := Equation1571_implies_Equation8 G h
+  have eq40 := Equation1571_implies_Equation40 G h
+  intro x y
+  apply Eq.symm
+  apply Eq.trans $ congrArg (fun w ↦ y ∘ (y ∘ w)) (eq8 x)
+  rw [eq40 x y]
+  apply Eq.trans $ (congrArg (fun w ↦ w ∘ (y ∘ (x ∘ (y ∘ y))))) (eq8 y)
+  exact Eq.symm $ (h x y (y ∘ y))
+
+@[equational_result]
+theorem Equation1571_implies_Equation43 (G: Type*) [Magma G] (h: Equation1571 G) : Equation43 G := by
+  have eq16 := Equation1571_implies_Equation16 G h
+  have eq23 := Equation1571_implies_Equation23 G h
+  have eq40 := Equation1571_implies_Equation40 G h
+  intro x y
+  apply Eq.trans $ h _ (x ∘ x) (x ∘ (x ∘ y))
+  rw [← h x x y, ← eq23 x, ← eq16 y x, eq40 x y, ← eq23 y]
+
 /-- This result was first obtained by Kisielewicz in 1997 via computer assistance. -/
 @[equational_result]
 theorem Equation1689_implies_Equation2 (G: Type*) [Magma G] (h: Equation1689 G) : Equation2 G:= by


### PR DESCRIPTION
Found out from [this MSE post](https://math.stackexchange.com/questions/3723155/can-a-single-nontrivial-identity-imply-associativity-and-commutativity) that the law `Equation1571` has several interesting consequences, and in fact axiomatizes abelian groups of exponent 2. Proved each of the following consequences, many of which are intermediate results on the way to proving commutativity and associativity:

- `Equation2662`
- `Equation40` (all squares equal)
- `Equation23` and `Equation8` (duals of each other)
- `Equation16`
- `Equation43` (commutativity)
- `Equation4512` (associativity)