### PR TITLE
fix error in Ruby scripts by addding require 'set'

### DIFF
--- a/scripts/graph.rb
+++ b/scripts/graph.rb
@@ -1,3 +1,4 @@
+require 'set'
 
 class Graph
   attr_accessor :adj_list


### PR DESCRIPTION
It seems that at least on a somewhat old Ruby version this is needed to have Set in scope.