### PR TITLE
feat: scoped instances and notation priority

### DIFF
--- a/equational_theories/Completeness.lean
+++ b/equational_theories/Completeness.lean
@@ -73,7 +73,7 @@ infix:50 " ⊧ " => (models)
 infix:50 " ⊢ " => (derive)
 
 theorem SubstEval {α} G [Magma G] (t : FreeMagma α) (σ : α → FreeMagma α) (φ : α → G) :
-    evalInMagma φ (t ⬝ σ) = evalInMagma (evalInMagma φ ∘ σ) t := by
+    evalInMagma φ (t ⬝ σ) = evalInMagma (evalInMagma φ <| σ ·) t := by
   cases t
   case Leaf => rfl
   case Fork t₁ t₂ => simp only [evalInMagma]; repeat rw [SubstEval]
@@ -138,7 +138,7 @@ instance FreeMagmaWithLaws.Magma {α} (Γ : Ctx α) : Magma (FreeMagmaWithLaws �
   { op := ForkWithLaws Γ }
 
 theorem FreeMagmaWithLaws.evalInMagmaIsQuot {α} (Γ : Ctx α) (t : FreeMagma α) (σ : α → FreeMagma α):
-    evalInMagma (embed Γ ∘ σ) t = embed Γ (t ⬝ σ) := by
+    evalInMagma (embed Γ <| σ ·) t = embed Γ (t ⬝ σ) := by
   cases t <;> rw [evalInMagma]
   case Leaf => rfl
   case Fork =>
@@ -153,15 +153,16 @@ theorem substLFId {α} (t : FreeMagma α) : t ⬝ Lf = t := by
   constructor <;> apply substLFId
 
 @[simp]
-def LfEmbed {α} (Γ : Ctx α) : α → FreeMagmaWithLaws Γ := embed Γ ∘ Lf
+def LfEmbed {α} (Γ : Ctx α) : α → FreeMagmaWithLaws Γ := (embed Γ <| Lf ·)
 
 -- Mostly forward reasoning here, so we delay the intros.
 theorem FreeMagmaWithLaws.isDerives {α} (Γ : Ctx α) (E : MagmaLaw α) :
   FreeMagmaWithLaws Γ ⊧ E → Nonempty (Γ ⊢ E) := by
   simp [satisfies, satisfiesPhi, evalInMagma]
-  intros eq; have h := (eq (LfEmbed Γ))
-  simp only [LfEmbed] at h
-  repeat rw [FreeMagmaWithLaws.evalInMagmaIsQuot] at h
+  intros eq;
+  have h := eq (LfEmbed Γ)
+  unfold LfEmbed at h
+  repeat rw [FreeMagmaWithLaws.evalInMagmaIsQuot (σ := Lf)] at h
   have h' := Quotient.exact h
   simp [HasEquiv.Equiv, Setoid.r, RelOfLaws] at h'
   repeat rw [substLFId] at h'
@@ -177,7 +178,7 @@ theorem PhiAsSubst_aux {α} (Γ : Ctx α) (φ : α → FreeMagmaWithLaws Γ) :
   symm; trivial
 
 theorem PhiAsSubst {α} (Γ : Ctx α) (φ : α → FreeMagmaWithLaws Γ) :
-  ∃ (σ : α → FreeMagma α), φ = (embed Γ) ∘ σ := by
+  ∃ (σ : α → FreeMagma α), φ = (embed Γ <| σ ·) := by
   have ⟨σ, h⟩ := PhiAsSubst_aux Γ φ
   exact ⟨σ, funext fun x ↦ h x⟩
 

--- a/equational_theories/Magma.lean
+++ b/equational_theories/Magma.lean
@@ -11,4 +11,37 @@ class Magma (α : Type _) where
   /-- `a ∘ b` computes a binary operation of `a` and `b`. -/
   op : α → α → α
 
-@[inherit_doc] infix:65 " ∘ " => Magma.op
+/-- `a ∘ b` computes a binary operation of `a` and `b`.
+
+We ensure that this notation has priority over function composition. This means that
+*function composition notation is not available in this repository*.
+Reason for this choice: the overloading caused huge slowdowns when compiling some definitions
+Zulip thread: https://leanprover.zulipchat.com/#narrow/stream/458659-Equational/topic/Symbol.20for.20.60Magma.2Eop.60 -/
+infix:65 (priority := high) " ∘ " => Magma.op
+
+
+/-! Test that the function composition notation now fails. -/
+
+/--
+error: failed to synthesize
+  Magma (Nat → Nat)
+Additional diagnostic information may be available using the `set_option diagnostics true` command.
+-/
+#guard_msgs(error) in
+example (g f : Nat → Nat) : g ∘ f = id := rfl
+
+/-- This instance is (only) available after writing `open MagmaToMul` -/
+scoped instance MagmaToMul.inst {α : Type _} [Magma α] : Mul α where
+  mul := Magma.op
+
+/-- This instance is (only) available after writing `open MagmaToAdd` -/
+scoped instance MagmaToAdd.inst {α : Type _} [Magma α] : Add α where
+  add := Magma.op
+
+/-- This instance is (only) available after writing `open MulToMagma` -/
+scoped instance MulToMagma.inst {α : Type _} [Mul α] : Magma α where
+  op := (· * ·)
+
+/-- This instance is (only) available after writing `open AddToMagma` -/
+scoped instance AddToMagma.inst {α : Type _} [Add α] : Magma α where
+  op := (· + ·)


### PR DESCRIPTION
* Adds scoped instances between `Add`, `Mul` and `Magma`.
* Make the priority of `∘` high for `Magma.op`, making it unusable as notation for `Function.comp`.