### PR TITLE
check axioms of equational results

### DIFF
--- a/equational_theories/EquationalResult.lean
+++ b/equational_theories/EquationalResult.lean
@@ -1,5 +1,6 @@
 import Lean.Elab.Exception
 import Lean.Elab.Declaration
+import Lean.Util.CollectAxioms
 
 import equational_theories.ParseImplications
 
@@ -68,6 +69,11 @@ initialize equationalResultAttr : Unit ←
     add   := fun declName _stx _attrKind => do
        let filename := (←read).fileName
        discard <| Meta.MetaM.run do
+       let axioms ← Lean.collectAxioms declName
+       for a in axioms do
+         if not (a ∈ [``propext, ``Classical.choice, ``Quot.sound]) then
+           throwError s!"declaration uses a prohibited axiom: {a}"
+
        let info ← getConstInfo declName
        let entry ← match info with
                    | .thmInfo  (val : TheoremVal) =>


### PR DESCRIPTION
Adds a validation step to make sure that theorems tagged with `@[equational_result]` do not
depend on any axioms other than `propext`, `Classical.choice`,  or `Quot.sound`. In particular,
this will report an error on usages of `sorry`.

This adds a little bit of work for each theorem tagged with `@[equational_result]`, but the aggregate
effect is rather small. I observed a clean build to take 8m8s before this change and 8m9s after this change.
