### PR TITLE
Move definitions of derivability and entailment out of `Completeness.lean`

### DIFF
--- a/equational_theories/Compactness.lean
+++ b/equational_theories/Compactness.lean
@@ -1,5 +1,6 @@
 import Mathlib.Data.Finset.Basic
 import equational_theories.Completeness
+import equational_theories.MagmaLaw
 
 open Law
 

--- a/equational_theories/Completeness.lean
+++ b/equational_theories/Completeness.lean
@@ -2,75 +2,11 @@
 -- we roughly follow Baader & Nipkow's "Term Rewriting and All That",
 -- and
 import equational_theories.FreeMagma
+import equational_theories.MagmaLaw
 import Mathlib.Data.Set.Defs
 
 open FreeMagma
-
-namespace Law
-
-structure MagmaLaw (α : Type) where
-  lhs : FreeMagma α
-  rhs : FreeMagma α
-deriving DecidableEq
-
-infix:60 " ≃ " => MagmaLaw.mk
-
-end Law
-
 open Law
-
-def substFreeMagma {α β} (t : FreeMagma α) (σ : α → FreeMagma β) : FreeMagma β :=
-match t with
-| .Leaf a => σ a
-| t₁ ⋆ t₂ => substFreeMagma t₁ σ ⋆ substFreeMagma t₂ σ
-
-infix:66 " ⬝ " => substFreeMagma
-
-@[inline, simp]
-def Ctx α := Set (MagmaLaw α)
-
--- FIXME: figure out how to remove this.
-instance Ctx.Membership α : Membership (MagmaLaw α) (Ctx α) := ⟨ Set.instMembership.mem ⟩
-
-instance {α : Type} : Singleton (MagmaLaw α) (Ctx α) := ⟨Set.singleton⟩
-
-section DeriveDef
-
-set_option hygiene false
-
-local infix:50 " ⊢ " =>  derive
-
--- We keep this in type, because we're going to want to gather
--- the (finite!) set of required axioms later.
-inductive derive {α} : Ctx α → MagmaLaw α → Type :=
-  | Ax Γ E (h : E ∈ Γ) : Γ ⊢ E
-  | Ref Γ t : Γ ⊢ (t ≃ t)
-  | Sym Γ t u : Γ ⊢ (t ≃ u) → Γ ⊢ (u ≃ t)
-  | Trans Γ t u v : Γ ⊢ (t ≃ u) → Γ ⊢ (u ≃ v) → Γ ⊢ (t ≃ v)
-  -- This is not as polymorphic as it could be, shouldn't be an issue at the moment
-  | Subst Γ t u σ : Γ ⊢ (t ≃ u) → Γ ⊢ (t ⬝ σ ≃ u ⬝ σ)
-  | Cong Γ t₁ t₂ u₁ u₂ : Γ ⊢ (t₁ ≃ t₂) → Γ ⊢ (u₁ ≃ u₂) → Γ ⊢ (t₁ ⋆ u₁ ≃ t₂ ⋆ u₂)
-
-end DeriveDef
-
-def satisfiesPhi {α G : Type} [Magma G] (φ : α → G) (E : MagmaLaw α) : Prop :=
-  E.lhs.evalInMagma φ = E.rhs.evalInMagma φ
-
-def satisfies {α : Type} (G : Type) [Magma G] (E : MagmaLaw α) := ∀ (φ : α → G), satisfiesPhi φ E
-
-def satisfiesSet {α : Type} (G : Type) [Magma G] (Γ : Set (MagmaLaw α)) : Prop :=
-  ∀ E ∈ Γ, satisfies G E
-
-def models {α} (Γ : Ctx α) (E : MagmaLaw α) : Prop :=
-  ∀ (G : Type)[Magma G], satisfiesSet G Γ → satisfies G E
-
-infix:50 " ⊧ " => (satisfies)
-
-infix:50 " ⊧ " => (satisfiesSet)
-
-infix:50 " ⊧ " => (models)
-
-infix:50 " ⊢ " => (derive)
 
 theorem SubstEval {α} G [Magma G] (t : FreeMagma α) (σ : α → FreeMagma α) (φ : α → G) :
     evalInMagma φ (t ⬝ σ) = evalInMagma (evalInMagma φ ∘ σ) t := by
@@ -145,11 +81,11 @@ theorem FreeMagmaWithLaws.evalInMagmaIsQuot {α} (Γ : Ctx α) (t : FreeMagma α
     simp only [Magma.op, ForkWithLaws]
     repeat rw [FreeMagmaWithLaws.evalInMagmaIsQuot]
     simp only [Quotient.lift₂]
-    apply Quot.sound; rw [substFreeMagma]
+    apply Quot.sound; rw [evalInMagma]
     exact ⟨derive.Ref _ _⟩
 
 theorem substLFId {α} (t : FreeMagma α) : t ⬝ Lf = t := by
-  cases t <;> simp [substFreeMagma]
+  cases t <;> simp [evalInMagma]
   constructor <;> apply substLFId
 
 @[simp]

--- a/equational_theories/Completeness.lean
+++ b/equational_theories/Completeness.lean
@@ -81,11 +81,11 @@ theorem FreeMagmaWithLaws.evalInMagmaIsQuot {α} (Γ : Ctx α) (t : FreeMagma α
     simp only [Magma.op, ForkWithLaws]
     repeat rw [FreeMagmaWithLaws.evalInMagmaIsQuot]
     simp only [Quotient.lift₂]
-    apply Quot.sound; rw [evalInMagma]
+    apply Quot.sound; rw [substFreeMagma]
     exact ⟨derive.Ref _ _⟩
 
 theorem substLFId {α} (t : FreeMagma α) : t ⬝ Lf = t := by
-  cases t <;> simp [evalInMagma]
+  cases t <;> simp [substFreeMagma]
   constructor <;> apply substLFId
 
 @[simp]

--- a/equational_theories/FreeComm.lean
+++ b/equational_theories/FreeComm.lean
@@ -7,7 +7,7 @@
 import Mathlib.Data.Multiset.Basic
 import Mathlib.Algebra.BigOperators.Finprod
 import equational_theories.FreeMagma
-import equational_theories.Completeness
+import equational_theories.MagmaLaw
 
 
 open Law

--- a/equational_theories/MagmaLaw.lean
+++ b/equational_theories/MagmaLaw.lean
@@ -1,0 +1,69 @@
+import equational_theories.FreeMagma
+import Mathlib.Data.Set.Defs
+
+set_option hygiene false
+
+open FreeMagma
+
+namespace Law
+
+structure MagmaLaw (α : Type) where
+  lhs : FreeMagma α
+  rhs : FreeMagma α
+deriving DecidableEq
+
+infix:60 " ≃ " => MagmaLaw.mk
+
+end Law
+
+open Law
+
+def substFreeMagma {α β} (t : FreeMagma α) (σ : α → FreeMagma β) : FreeMagma β :=
+match t with
+| .Leaf a => σ a
+| t₁ ⋆ t₂ => substFreeMagma t₁ σ ⋆ substFreeMagma t₂ σ
+
+infix:66 " ⬝ " => substFreeMagma
+
+@[inline, simp]
+def Ctx α := Set (MagmaLaw α)
+
+-- FIXME: figure out how to remove this.
+instance Ctx.Membership α : Membership (MagmaLaw α) (Ctx α) := ⟨ Set.instMembership.mem ⟩
+
+instance {α : Type} : Singleton (MagmaLaw α) (Ctx α) := ⟨Set.singleton⟩
+
+/-- Definition of derivability -/
+local infix:50 " ⊢ " =>  derive
+
+-- We keep this in type, because we're going to want to gather
+-- the (finite!) set of required axioms later.
+inductive derive {α} : Ctx α → MagmaLaw α → Type :=
+  | Ax Γ E (h : E ∈ Γ) : Γ ⊢ E
+  | Ref Γ t : Γ ⊢ (t ≃ t)
+  | Sym Γ t u : Γ ⊢ (t ≃ u) → Γ ⊢ (u ≃ t)
+  | Trans Γ t u v : Γ ⊢ (t ≃ u) → Γ ⊢ (u ≃ v) → Γ ⊢ (t ≃ v)
+  -- This is not as polymorphic as it could be, shouldn't be an issue at the moment
+  | Subst Γ t u σ : Γ ⊢ (t ≃ u) → Γ ⊢ (t ⬝ σ ≃ u ⬝ σ)
+  | Cong Γ t₁ t₂ u₁ u₂ : Γ ⊢ (t₁ ≃ t₂) → Γ ⊢ (u₁ ≃ u₂) → Γ ⊢ (t₁ ⋆ u₁ ≃ t₂ ⋆ u₂)
+
+/-- Definitions of entailment -/
+def satisfiesPhi {α G : Type} [Magma G] (φ : α → G) (E : MagmaLaw α) : Prop :=
+  E.lhs.evalInMagma φ = E.rhs.evalInMagma φ
+
+def satisfies {α : Type} (G : Type) [Magma G] (E : MagmaLaw α) := ∀ (φ : α → G), satisfiesPhi φ E
+
+def satisfiesSet {α : Type} (G : Type) [Magma G] (Γ : Set (MagmaLaw α)) : Prop :=
+  ∀ E ∈ Γ, satisfies G E
+
+def models {α} (Γ : Ctx α) (E : MagmaLaw α) : Prop :=
+  ∀ (G : Type)[Magma G], satisfiesSet G Γ → satisfies G E
+
+/-- Notation for derivability and entailment -/
+infix:50 " ⊧ " => (satisfies)
+
+infix:50 " ⊧ " => (satisfiesSet)
+
+infix:50 " ⊧ " => (models)
+
+infix:50 " ⊢ " => (derive)

--- a/equational_theories/MagmaOp.lean
+++ b/equational_theories/MagmaOp.lean
@@ -4,9 +4,10 @@
 -/
 
 import equational_theories.FreeMagma
-import equational_theories.Completeness
+import equational_theories.MagmaLaw
 
 open FreeMagma
+open Law
 
 def FreeMagma.op {α} (w : FreeMagma α) : FreeMagma α :=
 match w with

--- a/equational_theories/Preorder.lean
+++ b/equational_theories/Preorder.lean
@@ -1,6 +1,8 @@
 import Mathlib.Order.Defs
 import Mathlib.Data.Set.Basic
-import equational_theories.Completeness
+import equational_theories.MagmaLaw
+
+open Law
 
 namespace MagmaLaw
 


### PR DESCRIPTION
The definitions of derivability and entailment belong in a separate file (which I've called `MagmaLaw.lean`). It should not be necessary to import all of `Completeness.lean` in order to use these definitions.