### PR TITLE
A new tool to find "powerful" theorems

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ To build this project after [installing Lean](https://www.lean-lang.org/lean-get
         - [`explore_magma`](scripts/explore_magma.py) - test a given magma table against all or a subset of the equations in `AllEquations.lean`
         - [`find_dual`](scripts/find_dual.py) - finds the dual of an equation
         - [`find_equation_id`](scripts/find_equation_id.py) - finds the equation number of an equation string
+        - [`find_powerful_theorems.py`](scripts/find_powerful_theorems.py) - finds theorems that, if proved, would imply many others
         - [`generate_eqs_list`](scripts/generate_eqs_list.py) - generates a list of equations
         - [`generate_graphviz_graph`](scripts/generate_graphviz_graph.rb) - generates a graphviz dot file, that can be used to create an implication graph
         - [`generate_image`](scripts/generate_image.py) - generates an image of implications

--- a/scripts/find_powerful_theorems.py
+++ b/scripts/find_powerful_theorems.py
@@ -1,0 +1,109 @@
+import numpy as np
+import json
+import argparse
+import subprocess
+from collections import defaultdict
+from scipy.sparse import csr_matrix
+from scipy.sparse.csgraph import connected_components
+from itertools import combinations
+
+def load_data_from_lean():
+    try:
+        result = subprocess.run(["lake", "exe", "extract_implications", "outcomes"], 
+                                capture_output=True, text=True, check=True)
+        return json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        return None
+
+def preprocess_data(data):
+    outcomes = data['outcomes']
+    reorder = data['equations']
+    order = [int(x[8:]) for x in reorder]
+    
+    ids = ["explicit_conjecture_false", "explicit_conjecture_true",
+           "explicit_proof_false", "explicit_proof_true",
+           "implicit_conjecture_false", "implicit_conjecture_true",
+           "implicit_proof_false", "implicit_proof_true", "unknown"]
+    ids = {x: i for i, x in enumerate(ids)}
+
+
+    n = 4694
+    r = np.zeros((n, n))
+    for i, row in enumerate(outcomes):
+        for j, col in enumerate(row):
+            if order[i] <= 4694 and order[j] <= 4694:
+                r[order[i]-1, order[j]-1] = ids[col]
+    
+    ok = (r == 1) | (r == 3) | (r == 5) | (r == 7)
+    no = (r == 0) | (r == 2) | (r == 4) | (r == 6)
+    matrix = ok + no * 2
+    
+    return matrix
+
+def find_most_useful_implication(matrix, k, one_per_equiv_class=True):
+    n = matrix.shape[0]
+    known_implications = csr_matrix((matrix == 1).astype(int))
+    n_components, labels = connected_components(known_implications, directed=True, connection='strong')
+    component_sizes = np.bincount(labels)
+    component_to_nodes = [np.where(labels == i)[0] for i in range(n_components)]
+    
+    component_pairs = sorted(
+        combinations(range(n_components), 2),
+        key=lambda pair: component_sizes[pair[0]] * component_sizes[pair[1]],
+        reverse=True
+    )
+    
+    top_implications = []
+    
+    for comp1, comp2 in component_pairs:
+        nodes1 = component_to_nodes[comp1]
+        nodes2 = component_to_nodes[comp2]
+        submatrix = matrix[np.ix_(nodes1, nodes2)]
+        unknown_mask = (submatrix == 0)
+        
+        if np.any(unknown_mask):
+            unknown_indices = np.argwhere(unknown_mask)
+            value = component_sizes[comp1] * component_sizes[comp2] - 1
+            
+            for i, j in unknown_indices:
+                actual_i, actual_j = nodes1[i], nodes2[j]
+                top_implications.append(((actual_i, actual_j), value))
+                
+                if len(top_implications) == k:
+                    return top_implications
+                
+                if one_per_equiv_class:
+                    break
+    
+    return top_implications
+
+def main():
+    parser = argparse.ArgumentParser(description="Find the most useful implications in a matrix.")
+    parser.add_argument("--topk", type=int, default=1, help="Return the k best theorems to prove")
+    parser.add_argument("--one-per-equiv", action="store_true", help="Return only one per equivalence class")
+    parser.add_argument("--load-cache", type=str, help="Load output from the cache file")
+    parser.add_argument("--save-cache", type=str, help="Save the output to a cache file")
+    
+    args = parser.parse_args()
+    
+    if args.load_cache:
+        with open(args.load_cache, 'rb') as f:
+            matrix = np.load(f)
+    else:
+        data = load_data_from_lean()
+        if data is None:
+            return
+        matrix = preprocess_data(data)
+        
+        if args.save_cache:
+            with open(args.save_cache, 'wb') as f:
+                np.save(f, matrix)
+    
+    implications = find_most_useful_implication(matrix, args.topk, args.one_per_equiv)
+    
+    print("EquationA", "EquationB", "ValueOfAImpliesB")
+    for (a, b), value in implications:
+        print(a+1, b+1, value)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/find_powerful_theorems.py
+++ b/scripts/find_powerful_theorems.py
@@ -63,7 +63,7 @@ def find_most_useful_implication(matrix, k, one_per_equiv_class=True):
         
         if np.any(unknown_mask):
             unknown_indices = np.argwhere(unknown_mask)
-            value = component_sizes[comp1] * component_sizes[comp2] - 1
+            value = component_sizes[comp1] * component_sizes[comp2]
             
             for i, j in unknown_indices:
                 actual_i, actual_j = nodes1[i], nodes2[j]


### PR DESCRIPTION
This is a tool that will find "powerful" theorems. (Theorems that, if proven, would give many free edges on the graph by implications).

It is slow the first time it runs, because it has to invoke lean to find all the implications that are proven or conjectured. You can cache the result of this computation, and after that, it takes ~2 seconds to find the next best edge to add. Alternatively, you can also ask it for the top k implications and that takes basically an identical amount of time. You can also ask for only one equation per equivalence class.

Right now it basically just tells you to prove anything that would imply Equation 2 because that gives you 1000+ edges for free. But in the future it may give more useful outputs when there's not so much low hanging fruit.

It works by finding the sizes of all equivalence classes, and then trying, in order, the classes from largest to smallest until it finds one with a missing edge between the two sets. This is fairly fast right now. It may become slow if we prune all the easy stuff, if so I can speed it up later.

```
usage: find_powerful_theorems.py [-h] [--topk TOPK] [--one-per-equiv] [--load-cache LOAD_CACHE] [--save-cache SAVE_CACHE]

Find the most useful implications in a matrix.

optional arguments:
  -h, --help            show this help message and exit
  --topk TOPK           Return the k best theorems to prove
  --one-per-equiv       Return only one per equivalence class
  --load-cache LOAD_CACHE
                        Load output from the cache file
  --save-cache SAVE_CACHE
                        Save the output to a cache file
```