### PR TITLE
Inlcude MagmaEgg implications in build (and fix-up application symbol)

### DIFF
--- a/equational_theories/Generated.lean
+++ b/equational_theories/Generated.lean
@@ -7,4 +7,5 @@ import equational_theories.Generated.All4x4Tables
 import equational_theories.Generated.EquationSearch
 import equational_theories.Generated.Equation1
 import equational_theories.Generated.FinSearch
+import equational_theories.Generated.MagmaEgg.small
 

--- a/equational_theories/Generated/MagmaEgg/small/_000.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_000.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_001.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_001.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_002.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_002.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_003.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_003.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_004.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_004.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_005.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_005.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_006.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_006.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_007.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_007.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_008.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_008.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_009.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_009.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_010.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_010.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_011.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_011.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_012.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_012.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_013.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_013.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_014.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_014.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_015.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_015.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_016.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_016.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_017.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_017.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm

--- a/equational_theories/Generated/MagmaEgg/small/_018.lean
+++ b/equational_theories/Generated/MagmaEgg/small/_018.lean
@@ -1,7 +1,7 @@
 import equational_theories.AllEquations
 import equational_theories.Magma
 
-private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ∘ c = b ∘ d := by
+private def congr_op {G: Type _} [Magma G] {a b c d: G} (h1: a = b) (h2: c = d): a ◇ c = b ◇ d := by
   rw [h1, h2]
 private abbrev T := @Eq.trans
 private abbrev S := @Eq.symm


### PR DESCRIPTION
The previous PR adding these implications (#216) did not include the implications in Generated.lean so they haven't gotten picked up by the main build and all the subsequent tooling (dashboards, etc.)

Add it to Generated.lean, and fix-up the changed application symbol.