### PR TITLE
fix another bug in outcomes_to_image index ordering

### DIFF
--- a/scripts/outcomes_to_image.py
+++ b/scripts/outcomes_to_image.py
@@ -74,8 +74,11 @@ if __name__ == '__main__':
     # `eqid` is an Equation number.
 
     eqid_from_matrixidx = list(map(name_to_id, eqs))
+
+    # `imageidx` is just the index of the equation when all of the present
+    # equations are sorted by their equation number.
     imageidx_from_eqid = dict()
-    for imageidx, eqid in enumerate(eqid_from_matrixidx):
+    for imageidx, eqid in enumerate(sorted(eqid_from_matrixidx)):
         imageidx_from_eqid[eqid] = imageidx
 
     img = Image.new('RGB', (size, size))


### PR DESCRIPTION
In #268 I forgot to sort the equation numbers. After this change, the output images look even more regular:

![outcomes](https://github.com/user-attachments/assets/6c88ba4c-f3d8-4ac4-b838-daf221104e82)
