### PR TITLE
chore: mark counterexamples as such in `explore_magma`

### DIFF
--- a/scripts/explore_magma.py
+++ b/scripts/explore_magma.py
@@ -277,11 +277,12 @@ def main():
         assert "◇" not in transformations[-1]
         if print_transformations:
             for transformation in transformations[1:]:
-                print(
-                    f"       {transformation}".replace(
-                        " = ", " = " if passed else " ≠ "
+                if not passed:
+                    transformation = transformation.replace(" = ", " ≠ ")
+                    transformation = transformation.replace(
+                        "# example ", "# counterexample "
                     )
-                )
+                print(f"       {transformation}")
             print("")
     print("```")
     print("")


### PR DESCRIPTION
Mark counterexamples as such:

> [!NOTE]
> `% scripts/explore_magma.py "[[2, 2, 0, 3], [2, 2, 1, 0], [2, 2, 0, 3], [2, 3, 1, 0]]" --ids 1,2 --verbose`
```
Magma table: [[2, 2, 0, 3], [2, 2, 1, 0], [2, 2, 0, 3], [2, 3, 1, 0]]

|       | **0** | **1** | **2** | **3** |
|-------|-------|-------|-------|-------|
| **0** |   2   |   2   |   0   |   3   |
| **1** |   2   |   2   |   1   |   0   |
| **2** |   2   |   2   |   0   |   3   |
| **3** |   2   |   3   |   1   |   0   |

0 ◇ 0 = 2     0 ◇ 1 = 2     0 ◇ 2 = 0     0 ◇ 3 = 3
1 ◇ 0 = 2     1 ◇ 1 = 2     1 ◇ 2 = 1     1 ◇ 3 = 0
2 ◇ 0 = 2     2 ◇ 1 = 2     2 ◇ 2 = 0     2 ◇ 3 = 3
3 ◇ 0 = 2     3 ◇ 1 = 3     3 ◇ 2 = 1     3 ◇ 3 = 0

    1. x = x ✅
       1 = 1 # example with x=1

    2. x = y ❌
       0 ≠ 1 # counterexample with x=0, y=1

Magma tested against 2 equations:
* 1 passed (50.0%)
* 1 failed (50.0%)
```
