### PR TITLE
update blueprint (add \lean, \leanok)

### DIFF
--- a/blueprint/src/chapter/egraphs.tex
+++ b/blueprint/src/chapter/egraphs.tex
@@ -25,7 +25,7 @@ Some of these seem to be missing in the computation of the transitive closure of
 \begin{theorem}[14 implies 23]\label{14_implies_23} \uses{eq23,eq14}\lean{Subgraph.Equation14_implies_Equation23}\leanok  Definition \ref{eq14} is equivalent to Definition \ref{eq23}.
 \end{theorem}
 
-\begin{proof}
+\begin{proof}\leanok
 
 $$ x = (x \op x) \op (x \op (x \op x)) = (x \op x) \op x $$
 \end{proof}

--- a/blueprint/src/chapter/implications.tex
+++ b/blueprint/src/chapter/implications.tex
@@ -48,10 +48,10 @@ This result was posed as Problem A1 from Putnam 2001.
 
 The following result was Problem A4 on Putnam 1978.
 
-\begin{theorem}[3744 implies 3722, 381]\label{3744_implies_3722_381}\uses{eq3744, eq3722, eq381} Definition \ref{eq3744} implies Definition \ref{eq3722} and Definition \ref{eq381}.
+\begin{theorem}[3744 implies 3722, 381]\label{3744_implies_3722_381}\uses{eq3744, eq3722, eq381}\lean{Subgraph.Equation3744_implies_Equation3722, Subgraph.Equation3744_implies_Equation381}\leanok Definition \ref{eq3744} implies Definition \ref{eq3722} and Definition \ref{eq381}.
 \end{theorem}
 
-\begin{proof} By hypothesis, one has
+\begin{proof}\leanok By hypothesis, one has
 $$x \op y = (x \op z) \op (w \op y)
   $$
 for all $x,y,z,w$.  Various specializations of this give
@@ -65,7 +65,7 @@ $$ x \op y = (x\op z) \op y$$
 which is Definition \ref{eq381}.
 \end{proof}
 
-\begin{theorem}[1689 is equivalent to 2]\label{1689_equiv_2}\uses{eq1689, eq2} Definition \ref{eq1689} is equivalent to Definition \ref{eq2}.
+\begin{theorem}[1689 is equivalent to 2]\label{1689_equiv_2}\uses{eq1689, eq2}\lean{Subgraph.Equation1689_implies_Equation2, Subgraph.Equation2_implies_Equation1689}\leanok Definition \ref{eq1689} is equivalent to Definition \ref{eq2}.
 \end{theorem}
 
 


### PR DESCRIPTION
Some theorems and proofs in the blueprint have been formalized, but \lean or \leanok are not added in the corresponding places in the tex files. This PR fixes it.