### PR TITLE
more compact representation for the z3 counterexample

### DIFF
--- a/equational_theories/Z3Counterexamples.lean
+++ b/equational_theories/Z3Counterexamples.lean
@@ -24,73 +24,18 @@ Found with the following Z3 spec:
 ```
 -/
 
-def f_834_10 : Fin 8 → Fin 8 →  Fin 8
-| 0b010, 0b101 => ⟨0b110, by omega⟩
-| 0b101, 0b110 => ⟨0b111, by omega⟩
-| 0b101, 0b101 => ⟨0b000, by omega⟩
-| 0b101, 0b100 => ⟨0b101, by omega⟩
-| 0b110, 0b110 => ⟨0b000, by omega⟩
-| 0b110, 0b101 => ⟨0b000, by omega⟩
-| 0b101, 0b010 => ⟨0b110, by omega⟩
-| 0b010, 0b010 => ⟨0b101, by omega⟩
-| 0b110, 0b010 => ⟨0b110, by omega⟩
-| 0b110, 0b111 => ⟨0b000, by omega⟩
-| 0b111, 0b100 => ⟨0b001, by omega⟩
-| 0b101, 0b000 => ⟨0b101, by omega⟩
-| 0b010, 0b111 => ⟨0b010, by omega⟩
-| 0b111, 0b010 => ⟨0b111, by omega⟩
-| 0b000, 0b100 => ⟨0b001, by omega⟩
-| 0b010, 0b100 => ⟨0b010, by omega⟩
-| 0b100, 0b111 => ⟨0b011, by omega⟩
-| 0b010, 0b011 => ⟨0b110, by omega⟩
-| 0b000, 0b010 => ⟨0b000, by omega⟩
-| 0b100, 0b100 => ⟨0b011, by omega⟩
-| 0b100, 0b110 => ⟨0b100, by omega⟩
-| 0b110, 0b001 => ⟨0b110, by omega⟩
-| 0b111, 0b000 => ⟨0b100, by omega⟩
-| 0b011, 0b100 => ⟨0b011, by omega⟩
-| 0b000, 0b000 => ⟨0b100, by omega⟩
-| 0b000, 0b101 => ⟨0b000, by omega⟩
-| 0b000, 0b111 => ⟨0b001, by omega⟩
-| 0b000, 0b110 => ⟨0b100, by omega⟩
-| 0b110, 0b100 => ⟨0b110, by omega⟩
-| 0b101, 0b001 => ⟨0b101, by omega⟩
-| 0b111, 0b001 => ⟨0b111, by omega⟩
-| 0b100, 0b001 => ⟨0b011, by omega⟩
-| 0b001, 0b100 => ⟨0b010, by omega⟩
-| 0b001, 0b001 => ⟨0b001, by omega⟩
-| 0b001, 0b110 => ⟨0b001, by omega⟩
-| 0b011, 0b001 => ⟨0b010, by omega⟩
-| 0b001, 0b101 => ⟨0b001, by omega⟩
-| 0b001, 0b111 => ⟨0b001, by omega⟩
-| 0b111, 0b110 => ⟨0b100, by omega⟩
-| 0b000, 0b001 => ⟨0b001, by omega⟩
-| 0b100, 0b010 => ⟨0b100, by omega⟩
-| 0b010, 0b000 => ⟨0b010, by omega⟩
-| 0b001, 0b010 => ⟨0b001, by omega⟩
-| 0b111, 0b101 => ⟨0b100, by omega⟩
-| 0b100, 0b000 => ⟨0b011, by omega⟩
-| 0b010, 0b001 => ⟨0b010, by omega⟩
-| 0b001, 0b000 => ⟨0b011, by omega⟩
-| 0b100, 0b011 => ⟨0b100, by omega⟩
-| 0b110, 0b000 => ⟨0b100, by omega⟩
-| 0b010, 0b110 => ⟨0b010, by omega⟩
-| 0b110, 0b011 => ⟨0b110, by omega⟩
-| 0b000, 0b011 => ⟨0b000, by omega⟩
-| 0b001, 0b011 => ⟨0b010, by omega⟩
-| 0b011, 0b010 => ⟨0b101, by omega⟩
-| 0b100, 0b101 => ⟨0b100, by omega⟩
-| 0b011, 0b111 => ⟨0b011, by omega⟩
-| 0b011, 0b011 => ⟨0b010, by omega⟩
-| 0b111, 0b011 => ⟨0b111, by omega⟩
-| 0b101, 0b111 => ⟨0b000, by omega⟩
-| 0b111, 0b111 => ⟨0b001, by omega⟩
-| 0b101, 0b011 => ⟨0b101, by omega⟩
-| 0b011, 0b000 => ⟨0b011, by omega⟩
-| 0b011, 0b101 => ⟨0b011, by omega⟩
-| 0b011, 0b110 => ⟨0b011, by omega⟩
+def matrix_834_10 : List (List (Fin 8)) :=
+  [[4, 1, 0, 0, 1, 0, 4, 1],
+   [3, 1, 1, 2, 2, 1, 1, 1],
+   [2, 2, 5, 6, 2, 6, 2, 2],
+   [3, 2, 5, 2, 3, 3, 3, 3],
+   [3, 3, 4, 4, 3, 4, 4, 3],
+   [5, 5, 6, 5, 5, 0, 7, 0],
+   [4, 6, 6, 6, 6, 0, 0, 0],
+   [4, 7, 7, 7, 1, 4, 4, 1]]
 
-def Magma834_10 : Magma (Fin 8) where op := f_834_10
+def Magma834_10 : Magma (Fin 8)
+  where op := fun x y => (matrix_834_10.get! x.val).get! y.val
 
 -- TODO use calculate_facts to find more places where this magma helps.
 


### PR DESCRIPTION
Cleans up the counterexample added in #291 and perhaps makes it easier to add to the existing infrastructure for finite magmas, under `equational_theories/Generated/All4x4Tables`.