### PR TITLE
add outcomes png to dashboard

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -133,8 +133,7 @@ jobs:
 
       - name: Generate home_page/dashboard.md
         run: |
-          ~/.elan/bin/lake exe extract_implications outcomes equational_theories --hist > /tmp/hist.json
-          python scripts/generate_dashboard.py /tmp/hist.json
+          python scripts/generate_dashboard.py
 
       - name: Generate home_page/implications/implications.js
         run: |

--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -133,6 +133,7 @@ jobs:
 
       - name: Generate home_page/dashboard.md
         run: |
+          pip install pillow
           python scripts/generate_dashboard.py
 
       - name: Generate home_page/implications/implications.js


### PR DESCRIPTION
Adds the output of `outcomes_to_images.py` to the dashboard page.

Makes `generate_dashboard.py` responsible for launching subprocesses for whatever intermediate artifacts it needs. This way, the dashboard generating in `blueprint.yml` is reduced to a single line that calls `generate_dashboard.py`.

![Screenshot from 2024-10-05 14-15-24](https://github.com/user-attachments/assets/95ef2da4-a60a-4944-a1ee-c58fc7a3c523)
