### PR TITLE
Add missing word in discussion preceding Definition 1.6 of intro.tex

### DIFF
--- a/blueprint/src/chapter/intro.tex
+++ b/blueprint/src/chapter/intro.tex
@@ -67,7 +67,7 @@ is satisfied by a magma $G$ if and only if
 \begin{equation}\label{comm-law-2}
  x \op y = y \op x
 \end{equation}
-for all $x, y \in G$.  We refer to \eqref{comm-law-2} as the \emph{equation} associated to the law \eqref{comm-law}.  One can think of equations as the ``semantic'' interpretation of a ``syntactic'' law.  However, we shall often abuse notation and a law with its associated equation thus we shall (somewhat carelessly) also refer to \eqref{comm-law-2} as ``the commutative law'' (rather than ``the commutative equation'').
+for all $x, y \in G$.  We refer to \eqref{comm-law-2} as the \emph{equation} associated to the law \eqref{comm-law}.  One can think of equations as the ``semantic'' interpretation of a ``syntactic'' law.  However, we shall often abuse notation and identify a law with its associated equation.  In particular, we shall (somewhat carelessly) also refer to \eqref{comm-law-2} as ``the commutative law'' (rather than ``the commutative equation'').
 
 \begin{definition}[Models]\label{models-def}
   \lean{models}\leanok


### PR DESCRIPTION
The following fragment appears in the discussion preceding `Definition 1.6` of `intro.tex`:
```
However, we shall often abuse notation and a law with its associated equation
```
This PR inserts the word `identify` at the appropriate place in the above fragment:
```
However, we shall often abuse notation and identify a law with its associated equation
```
In addition, this PR also splits up the sentence containing this fragment into two sentences, to improve readability.