### PR TITLE
Correct typos in proof of Theorem 3.4 in infinite_models.tex

### DIFF
--- a/blueprint/src/chapter/infinite_models.tex
+++ b/blueprint/src/chapter/infinite_models.tex
@@ -38,25 +38,27 @@ A shorter Austin law of order $6$ was established in \cite{Kisielewicz}:
   Definition \ref{eq374794} is an Austin law.
 \end{theorem}
 
-\begin{proof} \leanok Suppose for contradiction that we have a non-trivial model of Definition \ref{eq374794}. Write $y^2 := y \op y$ and $y^3 := y^2 \op y$. For any $y,z$, introduce the functions $f_y: x \mapsto y^3 \op x$ and $g_{yz}: x \mapsto x \op (y^2 \op z)$.  Definition \ref{eq374794} says that $g_{yz}$ is a left-inverse of $f_y$, hence by finiteness these are inverses and $g_{yz}$ is independent of $z$. In particular
-$$ f(y^3) = g_{yy}(y^3) = g_{yz}(y^3) = f(y^2 \op z)$$
-and hence $y^2 \op z$ is independent of $z$.  Thus
-$$ f_y(x) = (y^2 \op y) \op x = (y^2 \op y^2) \op x$$
-is independent of $x$.  As $f_y$ is invertible, this forces the magma to be trivial, a contradiction.
+\begin{proof} \leanok  First we show that every finite model of Definition \ref{eq374794} is trivial.  Write $y^2 := y \op y$ and $y^3 := y^2 \op y$.  For any $y,z$, introduce the functions ${f_y: x \mapsto y^3 \op x}$ and ${g_{yz}: x \mapsto x \op (y^2 \op z)}$.  Definition \ref{eq374794} says that $g_{yz}(f_y(x))=x$, hence by finiteness $g_{yz}=f_y^{-1}$, showing that $g_{yz}$ does not depend on the value of $z$.  Since
+$$ f_y(y^2 \op z) = g_{yz}(y^3),$$
+it follows that $f_y(y^2 \op z)=f_y(y^3)$ which by injectivity of $f_y$ implies that $z\mapsto y^2 \op z$ is a constant function (with $y$ fixed).  Substituting $y^2$ for $y$ shows that the same is true for $z\mapsto (y^2 \op y^2) \op z$, and since
+$$ f_y(z) = (y^2 \op y) \op z = (y^2 \op y^2) \op z$$
+we conclude that $f_y$ is also a constant function.  But this function is already known to be injective, thus there do not exist distinct elements in its domain, showing that the model must be trivial.
 
-To construct an infinite magma, take the positive integers $\Z^+$ with the operation $x \op y$ defined as
-\begin{itemize}
-  \item $2^x$ if $y=x$;
-  \item $3^y$ if $x = 1 \neq y$;
-  \item $\min(j,1)$ if $x=3^j$ and $y \neq x$; and
-  \item $1$ otherwise.
-\end{itemize}
-Then $y^2 = 2^y$, $y^3 = 1$, and $y^2 \op z$ a power of two for all $y, z$, and $(1 \op x) \op w = x$ for all $x$ whenever $w$ is a power of two, so Definition \ref{eq374794} is satisfied.
+To construct an infinite model, consider the magma of positive integers $\Z^+$ with the operation $x \op y$ defined by
+$$
+x \op y = \begin{cases}
+2^x, & y=x\\
+3^y, & x=1,\ y\not=1\\
+\min(j, 1), & x=3^j,\ y \neq x\\
+1, & else
+\end{cases}.
+$$
+Then $y \op y = 2^y$ and $(y \op y) \op y = 1$ for all $y$.  Moreover, $(y \op y) \op z$ is a power of two for all $y, z$, and $(1 \op x) \op w = x$ for all $x$ whenever $w$ is a power of two.  It follows that this magma is a model of Definition \ref{eq374794}.
 \end{proof}
 
-An even shorter law (order $5$) was obtained by the same author in a followup paper \cite{Kisielewicz2}:
+An even shorter law (order $5$) was obtained by the same author in a follow-up paper \cite{Kisielewicz2}:
 
-\begin{theorem}[Kisielewicz theoremII]\label{kis-thm2}\uses{eq2} Definition \ref{eq28393} is an Austin law.
+\begin{theorem}[Kisielewicz theorem II]\label{kis-thm2}\uses{eq2} Definition \ref{eq28393} is an Austin law.
 \end{theorem}
 
 \begin{proof} Using the $y^2$ and $y^3$ notation as before, the law reads


### PR DESCRIPTION
This PR corrects minor inaccuracies in the proof of Theorem 3.4 in `infinite_models.tex`, which shows that a particular law of order 6 has no non-trivial finite models while possessing an infinite model.