### PR TITLE
split results about free magmas from their definitions

### DIFF
--- a/equational_theories.lean
+++ b/equational_theories.lean
@@ -1,6 +1,6 @@
 import equational_theories.Completeness
 import equational_theories.Compactness
-import equational_theories.FreeMagma
+import equational_theories.FreeMagmaImplications
 import equational_theories.FreeComm
 import equational_theories.MagmaOp
 import equational_theories.Subgraph

--- a/equational_theories/FreeMagma.lean
+++ b/equational_theories/FreeMagma.lean
@@ -1,4 +1,3 @@
-import equational_theories.AllEquations
 import equational_theories.EquationalResult
 import equational_theories.Homomorphisms
 
@@ -60,25 +59,3 @@ def evalHom {α : Type u} {G : Type v} [Magma G] (f : α → G) : FreeMagma α �
     EvalFreeMagmaUniversalProperty (Lf ∘ f)
 
 end FreeMagma
-
-theorem ExpressionEqualsAnything_implies_Equation2 (G: Type u) [Magma G] :
-    (∃ n : Nat, ∃ expr : FreeMagma (Fin n), ∀ x : G, ∀ sub : Fin n → G, x = expr.evalInMagma sub) → Equation2 G := by
-  intro ⟨n, expr, univ⟩ x y
-  let constx : Fin n → G := fun _ ↦ x
-  exact (univ x constx).trans (univ y constx).symm
-
-theorem Equation37_implies_Equation2 (G : Type u) [Magma G] :
-    (∀ x y z w : G, x = (y ◇ z) ◇ w) → Equation2 G :=
-  fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
-    3,
-    (Lf 0 ⋆ Lf 1) ⋆ Lf 2, -- The syntactic representation of (y ◇ z) ◇ w
-    fun k sub ↦ univ k (sub 0) (sub 1) (sub 2)
-  ⟩
-
-theorem Equation514_implies_Equation2 (G : Type u) [Magma G] :
-    (∀ x y : G, x = y ◇ (y ◇ (y ◇ y))) → Equation2 G :=
-  fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
-    1,
-    Lf 0 ⋆ (Lf 0 ⋆ (Lf 0 ⋆ Lf 0)), -- The syntactic representation of y ◇ (y ◇ (y ◇ y)))
-    fun k sub ↦ univ k (sub 0)
-  ⟩

--- a/equational_theories/FreeMagmaImplications.lean
+++ b/equational_theories/FreeMagmaImplications.lean
@@ -1,0 +1,26 @@
+import equational_theories.AllEquations
+import equational_theories.FreeMagma
+
+universe u
+
+theorem ExpressionEqualsAnything_implies_Equation2 (G: Type u) [Magma G] :
+    (∃ n : Nat, ∃ expr : FreeMagma (Fin n), ∀ x : G, ∀ sub : Fin n → G, x = expr.evalInMagma sub) → Equation2 G := by
+  intro ⟨n, expr, univ⟩ x y
+  let constx : Fin n → G := fun _ ↦ x
+  exact (univ x constx).trans (univ y constx).symm
+
+theorem Equation37_implies_Equation2 (G : Type u) [Magma G] :
+    (∀ x y z w : G, x = (y ◇ z) ◇ w) → Equation2 G :=
+  fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
+    3,
+    (Lf 0 ⋆ Lf 1) ⋆ Lf 2, -- The syntactic representation of (y ◇ z) ◇ w
+    fun k sub ↦ univ k (sub 0) (sub 1) (sub 2)
+  ⟩
+
+theorem Equation514_implies_Equation2 (G : Type u) [Magma G] :
+    (∀ x y : G, x = y ◇ (y ◇ (y ◇ y))) → Equation2 G :=
+  fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
+    1,
+    Lf 0 ⋆ (Lf 0 ⋆ (Lf 0 ⋆ Lf 0)), -- The syntactic representation of y ◇ (y ◇ (y ◇ y)))
+    fun k sub ↦ univ k (sub 0)
+  ⟩


### PR DESCRIPTION
This is needed so FreeMagma.lean doesn't depend on AllEquations, so we can break a cicrular dependency and use the `equation` command  to define "Laws" as well as "Equations" (towards #143)