### PR TITLE
chore: add `#!/usr/bin/env python3` to Python scripts meant to be executable

### DIFF
--- a/equational_theories/Generated/All4x4Tables/src/check_correct.py
+++ b/equational_theories/Generated/All4x4Tables/src/check_correct.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import numpy as np
 import collections
 import ast

--- a/equational_theories/Generated/All4x4Tables/src/check_redundant.py
+++ b/equational_theories/Generated/All4x4Tables/src/check_redundant.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import numpy as np
 def parse_line(line):
     # Extract the list from the line using string manipulation

--- a/equational_theories/Generated/All4x4Tables/src/double_check_3x3.py
+++ b/equational_theories/Generated/All4x4Tables/src/double_check_3x3.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import re
 import inspect
 import random

--- a/equational_theories/Generated/All4x4Tables/src/drive_c_parallel.py
+++ b/equational_theories/Generated/All4x4Tables/src/drive_c_parallel.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import subprocess
 import sys
 import os

--- a/equational_theories/Generated/All4x4Tables/src/dump_tables.py
+++ b/equational_theories/Generated/All4x4Tables/src/dump_tables.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 import numpy as np
 

--- a/equational_theories/Generated/All4x4Tables/src/generate_combined_refutations.sh
+++ b/equational_theories/Generated/All4x4Tables/src/generate_combined_refutations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: just run with ./generate_5x5_refutations.sh
 # Final output will be in the raw_lean_output folder.

--- a/equational_theories/Generated/All4x4Tables/src/generate_lean.py
+++ b/equational_theories/Generated/All4x4Tables/src/generate_lean.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 from collections import defaultdict
 import ast

--- a/equational_theories/Generated/All4x4Tables/src/prune.py
+++ b/equational_theories/Generated/All4x4Tables/src/prune.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import numpy as np
 import os
 import random

--- a/equational_theories/Generated/FinSearch/src/finsearch.py
+++ b/equational_theories/Generated/FinSearch/src/finsearch.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 import highspy
 import random

--- a/equational_theories/Generated/FinSearch/src/generate_lean.py
+++ b/equational_theories/Generated/FinSearch/src/generate_lean.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 from collections import defaultdict
 import ast

--- a/equational_theories/Generated/FinitePoly/src/finite_poly_generate_lean.py
+++ b/equational_theories/Generated/FinitePoly/src/finite_poly_generate_lean.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3
+#!/usr/bin/env python3
 
 from collections import defaultdict
 import ast

--- a/equational_theories/Generated/FinitePoly/src/generate_refutations.py
+++ b/equational_theories/Generated/FinitePoly/src/generate_refutations.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import re
 import inspect
 import random

--- a/equational_theories/Generated/SimpleRewrites/src/find_redundant.py
+++ b/equational_theories/Generated/SimpleRewrites/src/find_redundant.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 import re
 import os

--- a/equational_theories/Generated/SimpleRewrites/src/find_simple_rewrites.py
+++ b/equational_theories/Generated/SimpleRewrites/src/find_simple_rewrites.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import utils
 import os
 import re

--- a/equational_theories/Generated/VampireProven/src/vampire_proofs.py
+++ b/equational_theories/Generated/VampireProven/src/vampire_proofs.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import subprocess, json, random
 from tqdm import tqdm
 import time


### PR DESCRIPTION
A Python script has been made executable in a standard Unix environment when `chmod +x filename.py` has been applied and `#!/usr/bin/env python3` has been placed at the top.