### PR TITLE
Laws over Fin n translate over to nat (for n > 0)

### DIFF
--- a/equational_theories.lean
+++ b/equational_theories.lean
@@ -1,6 +1,6 @@
 import equational_theories.Completeness
 import equational_theories.Compactness
-import equational_theories.FreeMagma
+import equational_theories.FreeMagmaImplications
 import equational_theories.FreeComm
 import equational_theories.MagmaOp
 import equational_theories.Subgraph

--- a/equational_theories/EquationsCommand.lean
+++ b/equational_theories/EquationsCommand.lean
@@ -1,5 +1,6 @@
 import Lean
 import equational_theories.Magma
+import equational_theories.MagmaLaw
 
 open Lean Elab Command
 
@@ -8,12 +9,13 @@ For a more concise syntax, but more importantly to speed up elaboration (where t
 for each `◇` makes processing this file very slow) we defined custom syntax for defining
 equations, and a custom elaborator that instantiates the instante parameter of `◇`.
 -/
-elab mods:declModifiers tk:"equation " i:num " := " t:term : command => do
+elab mods:declModifiers tk:"equation " i:num " := " tsyn:term : command => do
   let G := mkIdent (← MonadQuotation.addMacroScope `G)
   let inst := mkIdent (← MonadQuotation.addMacroScope `inst)
   let eqName := mkIdent (.mkSimple s!"Equation{i.getNat}")
+  let lawName := mkIdent (.mkSimple s!"Law{i.getNat}")
   let mut is := #[]
-  let t := t.raw
+  let t := tsyn.raw
   -- Collect all identifiers to introduce them as parameters
   for s in t.topDown do
     if s.isIdent && !is.contains s then
@@ -27,6 +29,19 @@ elab mods:declModifiers tk:"equation " i:num " := " t:term : command => do
   for i in is.reverse do
     t ← `(∀ $(⟨i⟩) : $G, $t)
   elabCommand (← `(command| abbrev%$tk $eqName ($G : Type _) [$inst : Magma $G] := $t))
+  -- Create law
+  let tl := tsyn.raw
+  let tl ← tl.rewriteBottomUpM fun s => match s with
+    | `($a ◇ $b) => `(FreeMagma.Fork $a $b)
+    | `($a = $b) => `(Law.MagmaLaw.mk $a $b)
+    | _ => pure s
+  -- replace identifier `i` with `idx`.
+  let tl ← tl.rewriteBottomUpM fun s =>
+    match is.indexOf? s with
+      | some idx => `(FreeMagma.Leaf $(quote idx.val))
+      | none => pure s
+  let mut tl : Term := ⟨tl⟩
+  elabCommand (← `(command| abbrev%$tk $lawName : Law.MagmaLaw Nat := $tl))
   Command.liftTermElabM do
     let declMods ← elabModifiers mods
     -- Create a decl named `declName`

--- a/equational_theories/FreeMagma.lean
+++ b/equational_theories/FreeMagma.lean
@@ -1,4 +1,3 @@
-import equational_theories.AllEquations
 import equational_theories.EquationalResult
 import equational_theories.Homomorphisms
 
@@ -60,25 +59,3 @@ def evalHom {α : Type u} {G : Type v} [Magma G] (f : α → G) : FreeMagma α �
     EvalFreeMagmaUniversalProperty (Lf ∘ f)
 
 end FreeMagma
-
-theorem ExpressionEqualsAnything_implies_Equation2 (G: Type u) [Magma G] :
-    (∃ n : Nat, ∃ expr : FreeMagma (Fin n), ∀ x : G, ∀ sub : Fin n → G, x = expr.evalInMagma sub) → Equation2 G := by
-  intro ⟨n, expr, univ⟩ x y
-  let constx : Fin n → G := fun _ ↦ x
-  exact (univ x constx).trans (univ y constx).symm
-
-theorem Equation37_implies_Equation2 (G : Type u) [Magma G] :
-    (∀ x y z w : G, x = (y ◇ z) ◇ w) → Equation2 G :=
-  fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
-    3,
-    (Lf 0 ⋆ Lf 1) ⋆ Lf 2, -- The syntactic representation of (y ◇ z) ◇ w
-    fun k sub ↦ univ k (sub 0) (sub 1) (sub 2)
-  ⟩
-
-theorem Equation514_implies_Equation2 (G : Type u) [Magma G] :
-    (∀ x y : G, x = y ◇ (y ◇ (y ◇ y))) → Equation2 G :=
-  fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
-    1,
-    Lf 0 ⋆ (Lf 0 ⋆ (Lf 0 ⋆ Lf 0)), -- The syntactic representation of y ◇ (y ◇ (y ◇ y)))
-    fun k sub ↦ univ k (sub 0)
-  ⟩

--- a/equational_theories/FreeMagma.lean
+++ b/equational_theories/FreeMagma.lean
@@ -54,8 +54,13 @@ def evalHom {α : Type u} {G : Type v} [Magma G] (f : α → G) : FreeMagma α �
          (Eq.symm $ g.map_op' txleft txright)
    exact (funext equiv)
 
- theorem FmapFreeMagmaUniversalProperty {α : Type u} [Magma α] {β : Type u} (f : α → β)
+ theorem FmapFreeMagmaUniversalProperty {α : Type u} {β : Type u} (f : α → β)
     : ∀ g : FreeMagma α →◇ FreeMagma β, g ∘ Lf = Lf ∘ f → fmapFreeMagma f = g :=
     EvalFreeMagmaUniversalProperty (Lf ∘ f)
+
+theorem evalInMagma_comp {α β} {G} [Magma G] (f : α → β) (g : β → G) :
+  ∀ (x : FreeMagma α), evalInMagma (g ∘ f) x = evalInMagma g (fmapFreeMagma f x) := by
+  intro x
+  induction x <;> simp [fmapFreeMagma, evalInMagma, *]
 
 end FreeMagma

--- a/equational_theories/FreeMagmaImplications.lean
+++ b/equational_theories/FreeMagmaImplications.lean
@@ -1,0 +1,26 @@
+import equational_theories.AllEquations
+import equational_theories.FreeMagma
+
+universe u
+
+theorem ExpressionEqualsAnything_implies_Equation2 (G: Type u) [Magma G] :
+    (∃ n : Nat, ∃ expr : FreeMagma (Fin n), ∀ x : G, ∀ sub : Fin n → G, x = expr.evalInMagma sub) → Equation2 G := by
+  intro ⟨n, expr, univ⟩ x y
+  let constx : Fin n → G := fun _ ↦ x
+  exact (univ x constx).trans (univ y constx).symm
+
+theorem Equation37_implies_Equation2 (G : Type u) [Magma G] :
+    (∀ x y z w : G, x = (y ◇ z) ◇ w) → Equation2 G :=
+  fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
+    3,
+    (Lf 0 ⋆ Lf 1) ⋆ Lf 2, -- The syntactic representation of (y ◇ z) ◇ w
+    fun k sub ↦ univ k (sub 0) (sub 1) (sub 2)
+  ⟩
+
+theorem Equation514_implies_Equation2 (G : Type u) [Magma G] :
+    (∀ x y : G, x = y ◇ (y ◇ (y ◇ y))) → Equation2 G :=
+  fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
+    1,
+    Lf 0 ⋆ (Lf 0 ⋆ (Lf 0 ⋆ Lf 0)), -- The syntactic representation of y ◇ (y ◇ (y ◇ y)))
+    fun k sub ↦ univ k (sub 0)
+  ⟩

--- a/equational_theories/Preorder.lean
+++ b/equational_theories/Preorder.lean
@@ -79,4 +79,15 @@ instance : Preorder (MagmaLaw α) where
 theorem implies_eq_singleton_models {l₁ l₂ : MagmaLaw α} : l₁ ≤ l₂ ↔ {l₁} ⊧ l₂ := by
   simp only [LE.le, implies, models, satisfiesSet, Ctx, Set.mem_singleton_iff, forall_eq]
 
+theorem Law.implies_fin_implies_nat {n : Nat} (hn : n ≠ 0) {l₁ l₂ : MagmaLaw (Fin n)}
+  (h : l₁.implies l₂) : (l₁.fmap Fin.val).implies (l₂.fmap Fin.val) := by
+  intro G inst hG
+  rw [← satisfies_fin_satisfies_nat hn G l₂]
+  rw [← satisfies_fin_satisfies_nat hn G l₁] at hG
+  exact h hG
+
+theorem Law.leq_fin_leq_nat {n : Nat} (hn : n ≠ 0) {l₁ l₂ : MagmaLaw (Fin n)} (h : l₁ ≤ l₂) :
+  l₁.fmap Fin.val ≤ l₂.fmap Fin.val := by
+  apply Law.implies_fin_implies_nat hn; exact h
+
 end Law.MagmaLaw


### PR DESCRIPTION
This shows that if a law implies another one over `Fin n` (for `n > 0`) then so it is the case over `Nat`. This will allow the code in #356 and #357 to interact with each other and also to avoid casting between `Fin n` and `Fin m` all over the place when creating the transitive closure of implications over laws.
