### PR TITLE
add --extra flag to extract_implications

### DIFF
--- a/equational_theories/EquationalResult.lean
+++ b/equational_theories/EquationalResult.lean
@@ -55,6 +55,19 @@ initialize equationalResultsExtension : SimplePersistentEnvExtension Entry (Arra
     addEntryFn    := Array.push
   }
 
+def Entry.keepCore (e : Entry) : Option Entry :=
+  match e.variant with
+  | .implication { lhs, rhs } =>
+      if isCoreEquationName lhs && isCoreEquationName rhs
+      then some e
+      else none
+  | .facts { satisfied, refuted } =>
+      let sat1 := satisfied.filterMap filterCoreEquationName
+      let ref1 := refuted.filterMap filterCoreEquationName
+      if sat1.isEmpty || ref1.isEmpty then none
+      else some <| {e with variant := .facts {satisfied := sat1, refuted := ref1}}
+  | .unconditional eq => if isCoreEquationName eq then some e else none
+
 namespace Result
 
 private def equationalResultHelpString : String :=

--- a/equational_theories/ParseImplications.lean
+++ b/equational_theories/ParseImplications.lean
@@ -35,6 +35,14 @@ def getEquationName (app : Expr) : Option String := do
     some ("" ++ name.toString)
   | _ => none
 
+def isCoreEquationName (s : String) : Bool := Id.run do
+  if !s.startsWith "Equation" then return false
+  let some n := (s.toSubstring.drop 8).toNat? | return false
+  return 0 < n && n <= 4694
+
+def filterCoreEquationName (s : String) : Option String :=
+  if isCoreEquationName s then some s else none
+
 /--
 Extracts an `Implication` from two expressions of the form `EquationN G inst`.
 -/

--- a/scripts/extract_implications.lean
+++ b/scripts/extract_implications.lean
@@ -76,7 +76,8 @@ def Output.asJson (v : Output) : String :=
 
 def generateOutcomes (inp : Cli.Parsed) : IO UInt32 := do
   withExtractedResults inp fun rs => do
-    let (equations, outcomes) ← Closure.list_outcomes rs
+    let rs' := if inp.hasFlag "extra" then rs else rs.filterMap Entry.keepCore
+    let (equations, outcomes) ← Closure.list_outcomes rs'
     if inp.hasFlag "hist" then
       let mut count : Std.HashMap Closure.Outcome Nat := {}
       for a in outcomes do
@@ -94,6 +95,7 @@ def outcomes : Cmd := `[Cli|
 
   FLAGS:
     hist; "Create a histogram instead of outputting all outcomes"
+    extra; "Include extra equations that are not in the core set"
 
   ARGS:
     ...files : Array ModuleName; "The files to extract the implications from"


### PR DESCRIPTION
Adds logic to ignore equations outside of the core set of 4694. The filtering is by default enabled in `extract_implications`. The old behavior can still be accessed via a new `--extra` flag.

This will make the dashboard display information only about the core set.