### PR TITLE
Graphiti: Add links to README/dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Current statistics and data files, updated automatically:
 
 Current visualizations, updated automatically:
 - [Equation Explorer](https://teorth.github.io/equational_theories/implications) is a tool for exploring the graph of equation implications.
-- An experimental tool to interactively explore a Hasse diagram of the graph is available [here](https://tsyrklevi.ch/eqviz/index.html?2)
+- [Graphiti](https://teorth.github.io/equational_theories/graphiti) is a tool for visualizing the implication graph.
 
 For guidelines on how to contribute, see the [CONTRIBUTING.md](https://github.com/teorth/equational_theories/tree/main/CONTRIBUTING.md) file.  Participants are requested to abide by [our code of conduct](https://github.com/teorth/equational_theories/tree/main/CODE_OF_CONDUCT.md).
 
@@ -102,16 +102,15 @@ To build this project after [installing Lean](https://www.lean-lang.org/lean-get
         - [`find_equation_id`](https://github.com/teorth/equational_theories/tree/main/scripts/find_equation_id.py) - finds the equation number of an equation string
         - [`find_powerful_theorems.py`](https://github.com/teorth/equational_theories/tree/main/scripts/find_powerful_theorems.py) - finds theorems that, if proved, would imply many others
         - [`generate_eqs_list`](https://github.com/teorth/equational_theories/tree/main/scripts/generate_eqs_list.py) - generates a list of equations
-        - [`generate_graphviz_graph`](https://github.com/teorth/equational_theories/tree/main/scripts/generate_graphviz_graph.rb) - generates a graphviz dot file, that can be used to create an implication graph
         - [`generate_image`](https://github.com/teorth/equational_theories/tree/main/scripts/generate_image.py) - generates an image of implications
         - [`generate_most_wanted_list`](https://github.com/teorth/equational_theories/tree/main/scripts/generate_most_wanted_list.py) - generates the "most wanted" implications
         - [`generate_z3_counterexample`](https://github.com/teorth/equational_theories/tree/main/scripts/generate_z3_counterexample.py) - given an implication statement between two equations, calls Z3 to try to generate a counterexample
         - [`process_implications`](https://github.com/teorth/equational_theories/tree/main/scripts/process_implications.py) - processes implications from one or more Lean files
     - Ruby
         - [`generate_graphviz_graph`](https://github.com/teorth/equational_theories/tree/main/scripts/generate_graphviz_graph.rb) - creates a graphviz graph
-        - [`graph`](https://github.com/teorth/equational_theories/tree/main/scripts/graph.rb) - graph condensation tools
         - [`transitive_closure`](https://github.com/teorth/equational_theories/tree/main/scripts/transitive_closure.rb) - computes the transitive closure of a set of implications
         - [`transitive_reduction`](https://github.com/teorth/equational_theories/tree/main/scripts/transitive_reduction.rb) - finds a transitive reduction of a set of implications
+        - [`graph`](https://github.com/teorth/equational_theories/tree/main/scripts/graph.rb) - graph library
 - Automated provers for equational theories
     - [Prover9 and Mace4](https://www.cs.unm.edu/~mccune/prover9/)
         - [aa](https://github.com/gsfk/aa) - a project to use Prover9/Mace4 to brute force axioms for finite mathematical domains

--- a/home_page/_layouts/default.html
+++ b/home_page/_layouts/default.html
@@ -32,6 +32,7 @@
     <a href="{{site.url}}/docs" class="btn">Documentation</a>
     <a href="{{site.url}}/dashboard" class="btn">Dashboard</a>
     <a href="{{site.url}}/implications" class="btn">Equation Explorer</a>
+    <a href="{{site.url}}/graphiti" class="btn">Graphiti</a>
     {% if site.github.is_project_page %}
     <a href="{{ site.github.repository_url }}" class="btn">GitHub</a>
     {% endif %}

--- a/home_page/graphiti/index.html
+++ b/home_page/graphiti/index.html
@@ -189,6 +189,10 @@
           >Download SVG</a
         >
         ◇
+        <a href="#" id="download-link" onclick="downloadPNG(event)"
+          >Download PNG</a
+        >
+        ◇
         <a
           href="https://leanprover.zulipchat.com/#narrow/stream/458659-Equational/topic/Graphiti"
           >Leave feedback</a
@@ -308,6 +312,9 @@
       }
 
       function backToSearch(event) {
+        if (document.querySelector("svg")) {
+          document.querySelector("svg").remove();
+        }
         hideVisibility("graph");
         showVisibility("container");
 
@@ -326,12 +333,16 @@
 
       function downloadSVG(event) {
         event.preventDefault();
+
         // Select the SVG element
         var svgElement = document.querySelector("svg");
+        if (!svgElement) {
+          window.alert("Graph hasn't finished rendering yet");
+          return;
+        }
 
         // Serialize the SVG to a string
         var serializer = new XMLSerializer();
-        console.log(svgElement);
         var svgString = serializer.serializeToString(svgElement);
 
         // Create a Blob from the SVG string
@@ -352,20 +363,72 @@
         document.body.removeChild(link);
       }
 
+      function downloadPNG(event) {
+        event.preventDefault();
+
+        var svgElement = document.querySelector("svg");
+        if (!svgElement) {
+          window.alert("Graph hasn't finished rendering yet");
+          return;
+        }
+
+        // Convert the SVG to PNG after rendering
+        const svg = d3.select("#graph svg").node();
+        const serializer = new XMLSerializer();
+        const svgData = serializer.serializeToString(svg);
+        const canvas = document.createElement("canvas");
+        const context = canvas.getContext("2d");
+
+        // Create an image element to convert SVG to PNG
+        const img = new Image();
+        const svgBlob = new Blob([svgData], {
+          type: "image/svg+xml;charset=utf-8",
+        });
+        const url = URL.createObjectURL(svgBlob);
+        img.onload = function () {
+          // Set the scaling factor for higher resolution
+          const scaleFactor = 2; // Change this value for higher or lower resolution
+
+          const svgWidth = svg.width.baseVal.value;
+          const svgHeight = svg.height.baseVal.value;
+          canvas.width = svgWidth * scaleFactor; // Scale the width
+          canvas.height = svgHeight * scaleFactor; // Scale the height
+
+          // Set the context scale for drawing
+          context.scale(scaleFactor, scaleFactor);
+
+          // Draw the image on the canvas
+          context.drawImage(img, 0, 0);
+
+          URL.revokeObjectURL(url);
+
+          const pngUrl = canvas.toDataURL("image/png");
+          if (pngUrl.length < 100 || pngUrl === "data:image/png;base64,") {
+            window.alert("Failed to generate PNG, input likely too large");
+            return;
+          }
+
+          const a = document.createElement("a");
+          a.href = pngUrl;
+          a.download = "graph.png";
+          document.body.appendChild(a);
+          a.click();
+          document.body.removeChild(a);
+
+          console.log(55);
+        };
+
+        img.src = url;
+      }
+
       function onGraphRender() {
+        console.log("onGraphRender");
         document.getElementById("message").innerHTML = "";
 
         // Set vertex links to have target=_blank (e.g., open new tab)
-        d3.selectAll(".node").each(function (d) {
-          d3.select(this)
-            .select("a")
-            .each(function (text) {
-              d3.select(this).attr("target", "_blank");
-            });
-        });
+        d3.selectAll(".node").selectAll("a").attr("target", "_blank");
       }
 
-      var graphviz = d3.select("#graphSvg").graphviz();
       var graph_json = undefined;
 
       function vertices(adj_list) {
@@ -608,7 +671,11 @@ graph G {
         document.getElementById("graphSvg").innerHTML = "";
         showVisibility("graph");
         document.getElementById("message").innerHTML += "Rendering...<br />";
-        graphviz.renderDot(dotFile).on("end", onGraphRender);
+
+        d3.select("#graphSvg")
+          .graphviz({ tweenPaths: false, tweenShapes: false })
+          .renderDot(dotFile)
+          .on("end", onGraphRender);
       }
 
       const params = Object.fromEntries(

--- a/home_page/index.md
+++ b/home_page/index.md
@@ -27,7 +27,7 @@ Current statistics and data files, updated automatically:
 
 Current visualizations, updated automatically:
 - A tool for exploring the graph of equation implications is available [here](https://teorth.github.io/equational_theories/implications).
-- An experimental tool to interactively explore a Hasse diagram of the graph is available [here](https://tsyrklevi.ch/eqviz/index.html?2)
+- [Graphiti](https://teorth.github.io/equational_theories/graphiti) is a tool for visualizing the implication graph.
 
 For guidelines on how to contribute, see the [CONTRIBUTING.md](https://github.com/teorth/equational_theories/blob/main/CONTRIBUTING.md) file.  Participants are requested to abide by [our code of conduct](https://github.com/teorth/equational_theories/blob/main/CODE_OF_CONDUCT.md).
 
@@ -100,16 +100,15 @@ To build this project after [installing Lean](https://www.lean-lang.org/lean-get
         - [`find_equation_id`](https://github.com/teorth/equational_theories/blob/main/scripts/find_equation_id.py) - finds the equation number of an equation string
         - [`find_powerful_theorems.py`](https://github.com/teorth/equational_theories/blob/main/scripts/find_powerful_theorems.py) - finds theorems that, if proved, would imply many others
         - [`generate_eqs_list`](https://github.com/teorth/equational_theories/blob/main/scripts/generate_eqs_list.py) - generates a list of equations
-        - [`generate_graphviz_graph`](https://github.com/teorth/equational_theories/blob/main/scripts/generate_graphviz_graph.rb) - generates a graphviz dot file, that can be used to create an implication graph
         - [`generate_image`](https://github.com/teorth/equational_theories/blob/main/scripts/generate_image.py) - generates an image of implications
         - [`generate_most_wanted_list`](https://github.com/teorth/equational_theories/blob/main/scripts/generate_most_wanted_list.py) - generates the "most wanted" implications
         - [`generate_z3_counterexample`](https://github.com/teorth/equational_theories/blob/main/scripts/generate_z3_counterexample.py) - given an implication statement between two equations, calls Z3 to try to generate a counterexample
         - [`process_implications`](https://github.com/teorth/equational_theories/blob/main/scripts/process_implications.py) - processes implications from one or more Lean files
     - Ruby
         - [`generate_graphviz_graph`](https://github.com/teorth/equational_theories/blob/main/scripts/generate_graphviz_graph.rb) - creates a graphviz graph
-        - [`graph`](https://github.com/teorth/equational_theories/blob/main/scripts/graph.rb) - graph condensation tools
         - [`transitive_closure`](https://github.com/teorth/equational_theories/blob/main/scripts/transitive_closure.rb) - computes the transitive closure of a set of implications
         - [`transitive_reduction`](https://github.com/teorth/equational_theories/blob/main/scripts/transitive_reduction.rb) - finds a transitive reduction of a set of implications
+        - [`graph`](https://github.com/teorth/equational_theories/blob/main/scripts/graph.rb) - graph library
 - Automated provers for equational theories
     - [Prover9 and Mace4](https://www.cs.unm.edu/~mccune/prover9/)
         - [aa](https://github.com/gsfk/aa) - a project to use Prover9/Mace4 to brute force axioms for finite mathematical domains


### PR DESCRIPTION
Graphiti on home_page is live and the JSON was properly built in CI: https://teorth.github.io/equational_theories/graphiti/

I also included a new feature to download PNGs and a small rendering speed-up.