### PR TITLE
Complete confluence-based proofs

### DIFF
--- a/equational_theories/Confluence.lean
+++ b/equational_theories/Confluence.lean
@@ -564,4 +564,286 @@ theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [2038] [4270] := by
 
 end rw2038
 
+
+namespace rw3140
+
+variable [DecidableEq α]
+
+-- equation 3140 := x = (((y ◇ y) ◇ x) ◇ x) ◇ y
+def rule : FreeMagma α → FreeMagma α
+  | m@((((y1 ⋆ y2) ⋆ x) ⋆ x1) ⋆ y3) =>
+      if y1 = y2 ∧ y1 = y3 ∧ x = x1 then
+        x
+      else
+        m
+  | m => m
+
+instance rule_projection : IsProj (@rule α _) where
+  proj := by
+    intro x
+    unfold rule
+    split
+    · split
+      · right; left; right; left; right; right; rfl
+      · rfl
+    · rfl
+
+@[simp]
+theorem rule_yy (y : FreeMagma α) : rule (y ⋆ y) = y ⋆ y := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨heq, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+      have := FreeMagma.length_pos y1
+      omega
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rule_yyx {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule ((y ⋆ y) ⋆ x) = (y ⋆ y) ⋆ x := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨⟨rfl, rfl⟩, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, heq⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · rfl
+  · rfl
+
+@[simp]
+theorem rule_yyxx {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule (((y ⋆ y) ⋆ x) ⋆ x) = ((y ⋆ y) ⋆ x) ⋆ x := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨⟨⟨heq, rfl⟩, rfl⟩, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rule_yyxxy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule ((((y ⋆ y) ⋆ x) ⋆ x) ⋆ y) = x := by
+  simp [rule]
+
+@[equational_result]
+theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [3140] [614] := by
+  use ConfMagma (@rule Nat _), inferInstance
+  repeat' apply And.intro
+  · rintro ⟨x, hx⟩ ⟨y, hy⟩
+    simp [Magma.op]
+    apply Subtype.ext
+    simp only
+    simp [bu, hx, hy]
+  all_goals refute
+
+end rw3140
+
+namespace rw3143
+
+variable [DecidableEq α]
+
+-- equation 3143 := x = (((y ◇ y) ◇ x) ◇ y) ◇ y
+def rule : FreeMagma α → FreeMagma α
+  | m@((((y1 ⋆ y2) ⋆ x) ⋆ y3) ⋆ y4) =>
+      if y1 = y2 ∧ y1 = y3 ∧ y1 = y4 then
+        x
+      else
+        m
+  | m => m
+
+instance rule_projection : IsProj (@rule α _) where
+  proj := by
+    intro x
+    unfold rule
+    split
+    · split
+      · right; left; right; left; right; right; rfl
+      · rfl
+    · rfl
+
+@[simp]
+theorem rule_yy (y : FreeMagma α) : rule (y ⋆ y) = y ⋆ y := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨heq, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rule_yyx {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule ((y ⋆ y) ⋆ x) = (y ⋆ y) ⋆ x := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨⟨rfl, rfl⟩, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, heq, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+      have := FreeMagma.length_pos y1
+      omega
+    · rfl
+  · rfl
+
+@[simp]
+theorem rule_yyxy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule (((y ⋆ y) ⋆ x) ⋆ y) = ((y ⋆ y) ⋆ x) ⋆ y := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨⟨⟨heq, rfl⟩, rfl⟩, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rule_yyxyy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule ((((y ⋆ y) ⋆ x) ⋆ y) ⋆ y) = x := by
+  simp [rule]
+
+@[equational_result]
+theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [3143] [1629, 1832, 2644] := by
+  use ConfMagma (@rule Nat _), inferInstance
+  repeat' apply And.intro
+  · rintro ⟨x, hx⟩ ⟨y, hy⟩
+    simp [Magma.op]
+    apply Subtype.ext
+    simp only
+    simp [bu, hx, hy]
+  all_goals refute
+
+end rw3143
+
+
+namespace rw3150
+
+variable [DecidableEq α]
+
+-- equation 3150 := x = (((y ◇ y) ◇ y) ◇ x) ◇ y
+def rule : FreeMagma α → FreeMagma α
+  | m@((((y1 ⋆ y2) ⋆ y3) ⋆ x) ⋆ y4) =>
+      if y1 = y2 ∧ y1 = y3 ∧ y1 = y4 then
+        x
+      else
+        m
+  | m => m
+
+instance rule_projection : IsProj (@rule α _) where
+  proj := by
+    intro x
+    unfold rule
+    split
+    · split
+      · right; left; right; right; rfl
+      · rfl
+    · rfl
+
+@[simp]
+theorem rule_yy (y : FreeMagma α) : rule (y ⋆ y) = y ⋆ y := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨heq, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+      have := FreeMagma.length_pos y1
+      omega
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rule_yyx {α} [DecidableEq α] (y : FreeMagma α) :
+    rule ((y ⋆ y) ⋆ y) = (y ⋆ y) ⋆ y := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨⟨rfl, rfl⟩, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, heq⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · rfl
+  · rfl
+
+@[simp]
+theorem rule_yyyx {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule (((y ⋆ y) ⋆ y) ⋆ x) = ((y ⋆ y) ⋆ y) ⋆ x := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨⟨⟨heq, rfl⟩, rfl⟩, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rule_yyyxy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule ((((y ⋆ y) ⋆ y) ⋆ x) ⋆ y) = x := by
+  simp [rule]
+
+@[equational_result]
+theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [3150] [411, 1426, 2035] := by
+  use ConfMagma (@rule Nat _), inferInstance
+  repeat' apply And.intro
+  · rintro ⟨x, hx⟩ ⟨y, hy⟩
+    simp [Magma.op]
+    apply Subtype.ext
+    simp only
+    simp [bu, hx, hy]
+  all_goals refute
+
+end rw3150
+
+
 end Confluence

--- a/equational_theories/Confluence.lean
+++ b/equational_theories/Confluence.lean
@@ -217,10 +217,7 @@ theorem «Facts» :
   use ConfMagma (@rule Nat _), inferInstance
   repeat' apply And.intro
   · rintro ⟨x, hx⟩ ⟨y, hy⟩
-    simp [Magma.op]
-    apply Subtype.ext
-    simp only
-    simp [bu, hx, hy]
+    simp [Magma.op, bu, hx, hy]
   all_goals refute
 
 end rw477
@@ -310,10 +307,7 @@ theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [467] [2847] := by
   use ConfMagma (@rule Nat _), inferInstance
   repeat' apply And.intro
   · rintro ⟨x, hx⟩ ⟨y, hy⟩
-    simp [Magma.op]
-    apply Subtype.ext
-    simp only
-    simp [bu, hx, hy]
+    simp [Magma.op, bu, hx, hy]
   all_goals refute
 
 end rw467
@@ -403,10 +397,7 @@ theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [504] [817, 1629, 1832
   use ConfMagma (@rule Nat _), inferInstance
   repeat' apply And.intro
   · rintro ⟨x, hx⟩ ⟨y, hy⟩
-    simp [Magma.op]
-    apply Subtype.ext
-    simp only
-    simp [bu, hx, hy]
+    simp [Magma.op, bu, hx, hy]
   all_goals refute
 
 end rw504
@@ -479,10 +470,7 @@ theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [1515] [4590] := by
   use ConfMagma (@rule Nat _), inferInstance
   repeat' apply And.intro
   · rintro ⟨x, hx⟩ ⟨y, hy⟩
-    simp [Magma.op]
-    apply Subtype.ext
-    simp only
-    simp [bu, hx, hy]
+    simp [Magma.op, bu, hx, hy]
   all_goals refute
 
 end rw1515
@@ -556,10 +544,7 @@ theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [2038] [4270] := by
   use ConfMagma (@rule Nat _), inferInstance
   repeat' apply And.intro
   · rintro ⟨x, hx⟩ ⟨y, hy⟩
-    simp [Magma.op]
-    apply Subtype.ext
-    simp only
-    simp [bu, hx, hy]
+    simp [Magma.op, bu, hx, hy]
   all_goals refute
 
 end rw2038
@@ -650,10 +635,7 @@ theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [3140] [614] := by
   use ConfMagma (@rule Nat _), inferInstance
   repeat' apply And.intro
   · rintro ⟨x, hx⟩ ⟨y, hy⟩
-    simp [Magma.op]
-    apply Subtype.ext
-    simp only
-    simp [bu, hx, hy]
+    simp [Magma.op, bu, hx, hy]
   all_goals refute
 
 end rw3140
@@ -743,10 +725,7 @@ theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [3143] [1629, 1832, 26
   use ConfMagma (@rule Nat _), inferInstance
   repeat' apply And.intro
   · rintro ⟨x, hx⟩ ⟨y, hy⟩
-    simp [Magma.op]
-    apply Subtype.ext
-    simp only
-    simp [bu, hx, hy]
+    simp [Magma.op, bu, hx, hy]
   all_goals refute
 
 end rw3143
@@ -837,10 +816,7 @@ theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [3150] [411, 1426, 203
   use ConfMagma (@rule Nat _), inferInstance
   repeat' apply And.intro
   · rintro ⟨x, hx⟩ ⟨y, hy⟩
-    simp [Magma.op]
-    apply Subtype.ext
-    simp only
-    simp [bu, hx, hy]
+    simp [Magma.op, bu, hx, hy]
   all_goals refute
 
 end rw3150
@@ -930,10 +906,7 @@ theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [1110] [8, 411, 1629, 
   use ConfMagma (@rule Nat _), inferInstance
   repeat' apply And.intro
   · rintro ⟨x, hx⟩ ⟨y, hy⟩
-    simp [Magma.op]
-    apply Subtype.ext
-    simp only
-    simp [bu, hx, hy]
+    simp [Magma.op, bu, hx, hy]
   all_goals refute
 
 end rw1110

--- a/equational_theories/Confluence.lean
+++ b/equational_theories/Confluence.lean
@@ -421,5 +421,81 @@ theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [504] [817, 1629, 1832
 
 end rw504
 
+namespace rw1515
+
+variable [DecidableEq α]
+
+-- equation 1515 := x = (y ◇ y) ◇ (x ◇ (x ◇ x))
+def rule : FreeMagma α → FreeMagma α
+  | m@(.Fork (.Fork y1 y2) (.Fork x (.Fork x1 x2))) =>
+      if y1 = y2 ∧ x = x1 ∧ x = x2 then
+        x
+      else
+        m
+  | m => m
+
+instance rule_projection : IsProj (@rule α _) where
+  proj := by
+    intro x
+    unfold rule
+    split
+    · split
+      · right; right; right; left; rfl
+      · rfl
+    · rfl
+
+@[simp]
+theorem rule_yy (y : FreeMagma α) : rule (y ⋆ y) = y ⋆ y := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨rfl, heq⟩ := heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨rfl, heq⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rule_xyy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule (x ⋆ (y ⋆ y)) = x ⋆ (y ⋆ y) := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨rfl, rfl, heq⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rule_yyxxx {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule ((y ⋆ y) ⋆ (x ⋆ (x ⋆ x))) = x := by
+  simp [rule]
+
+@[equational_result]
+theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [1515] [817, 1629, 1832, 1925] := by
+  use ConfMagma (@rule Nat _), inferInstance
+  repeat' apply And.intro
+  · rintro ⟨x, hx⟩ ⟨y, hy⟩
+    simp [Magma.op]
+    apply Subtype.ext
+    simp only
+    simp [bu, hx, hy]
+  all_goals refute
+
+end rw1515
+
 
 end Confluence

--- a/equational_theories/Confluence.lean
+++ b/equational_theories/Confluence.lean
@@ -249,4 +249,102 @@ end rw477
 
 
 
+
+section rw467
+
+variable [DecidableEq α]
+
+-- equation 467 := x = y ◇ (x ◇ (x ◇ (y ◇ y)))
+def rw467 : FreeMagma α → FreeMagma α
+  | m@(.Fork y1 (.Fork x (.Fork x2 (.Fork y2 y3)))) =>
+      if y1 = y2 ∧ y1 = y3 ∧ x = x2 then
+        x
+      else
+        m
+  | m => m
+
+instance rw467_projection : IsProj (@rw467 α _) where
+  proj := by
+    intro x
+    unfold rw467
+    split
+    · split
+      · right; right; right; left; rfl
+      · rfl
+    · rfl
+
+@[simp]
+theorem rw467_yy (y : FreeMagma α) : rw467 (y ⋆ y) = y ⋆ y := by
+  unfold rw467
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨rfl, heq⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+      have := FreeMagma.length_pos y
+      omega
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rw467_xyy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rw467 (x ⋆ (y ⋆ y)) = x ⋆ (y ⋆ y) := by
+  unfold rw467
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨rfl, rfl, heq⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rw467_xxyy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rw467 (x ⋆ (x ⋆ (y ⋆ y))) = x ⋆ (x ⋆ (y ⋆ y)) := by
+  unfold rw467
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨rfl, rfl, rfl, heq⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rw467_yxxyy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rw467 (y ⋆ (x ⋆ (x ⋆ (y ⋆ y)))) = x := by
+  simp [rw467]
+
+@[equational_result]
+theorem Equation467_Facts :
+  ∃ (G : Type) (_ : Magma G), Facts G [467] [2847] := by
+  use ConfMagma (@rw467 Nat _), inferInstance
+  repeat' apply And.intro
+  · rintro ⟨x, hx⟩ ⟨y, hy⟩
+    simp [Magma.op]
+    apply Subtype.ext
+    simp only
+    simp [bu, hx, hy]
+  · intro h
+    replace h := h (0 : Nat)
+    revert h
+    decide
+
+end rw467
+
 end Confluence

--- a/equational_theories/Confluence.lean
+++ b/equational_theories/Confluence.lean
@@ -5,18 +5,14 @@ import equational_theories.FactsSyntax
 namespace FreeMagma
 
 variable {α : Type}
-/-
-inductive Everywhere (P : FreeMagma α → Prop) : FreeMagma α → Prop
-  | leaf (x : α) : P (.Leaf x) → Everywhere P (.Leaf x)
-  | fork (m1 m2 : FreeMagma α) : Everywhere P m1 → Everywhere P m2 → P (.Fork m1 m2) → Everywhere P (.Fork m1 m2)
--/
+
 def Everywhere (P : FreeMagma α → Prop) : FreeMagma α → Prop
   | .Leaf x => P (.Leaf x)
-  | .Fork x y => x.Everywhere P ∧ y.Everywhere P ∧ P (x ⋆ y)
+  | x ⋆ y => x.Everywhere P ∧ y.Everywhere P ∧ P (x ⋆ y)
 
 theorem Everywhere.top {P : FreeMagma α → Prop} : {x : FreeMagma α} → Everywhere P x → P x
   | .Leaf _ => fun h => h
-  | .Fork _ _ => fun h => h.2.2
+  | _ ⋆ _ => fun h => h.2.2
 
 @[simp]
 theorem Everywhere_idem {P : FreeMagma α → Prop} : Everywhere (Everywhere P) = Everywhere P := by
@@ -32,15 +28,9 @@ theorem Everywhere_idem {P : FreeMagma α → Prop} : Everywhere (Everywhere P) 
       exact h
     | Fork x y ihx ihy => exact ⟨ihx h.1, ihy h.2.1, h⟩
 
-/-
-inductive SubtermOf (x : FreeMagma α) : FreeMagma α → Prop where
-| here : SubtermOf x x
-| left a b : SubtermOf x a → SubtermOf x (a ⋆ b)
-| right a b : SubtermOf x b → SubtermOf x (a ⋆ b)
--/
 def SubtermOf (x : FreeMagma α) : (y : FreeMagma α) → Prop
 | .Leaf a => x = .Leaf a
-| .Fork a b => x = .Fork a b ∨ SubtermOf x a ∨ SubtermOf x b
+| a ⋆ b => x = a ⋆ b ∨ SubtermOf x a ∨ SubtermOf x b
 
 @[refl]
 theorem SubtermOf.refl (x : FreeMagma α) : SubtermOf x x := by
@@ -89,7 +79,7 @@ variable (rw : FreeMagma α → FreeMagma α)
 
 def bu : FreeMagma α → FreeMagma α
   | .Leaf x => .Leaf x
-  | .Fork x y => rw (bu x ⋆ bu y)
+  | x ⋆ y => rw (bu x ⋆ bu y)
 
 attribute [simp] bu.eq_1
 
@@ -147,7 +137,7 @@ variable [DecidableEq α]
 
 -- equation 477 := x = y ◇ (x ◇ (y ◇ (y ◇ y)))
 def rule : FreeMagma α → FreeMagma α
-  | m@(.Fork y1 (.Fork x (.Fork y2 (.Fork y3 y4)))) =>
+  | m@(y1 ⋆ (x ⋆ (y2 ⋆ (y3 ⋆ y4)))) =>
       if y1 = y2 ∧ y1 = y3 ∧ y1 = y4 then
         x
       else
@@ -241,7 +231,7 @@ variable [DecidableEq α]
 
 -- equation 467 := x = y ◇ (x ◇ (x ◇ (y ◇ y)))
 def rule : FreeMagma α → FreeMagma α
-  | m@(.Fork y1 (.Fork x (.Fork x2 (.Fork y2 y3)))) =>
+  | m@(y1 ⋆ (x ⋆ (x2 ⋆ (y2 ⋆ y3)))) =>
       if y1 = y2 ∧ y1 = y3 ∧ x = x2 then
         x
       else
@@ -334,7 +324,7 @@ variable [DecidableEq α]
 
 -- equation 504 := x = y ◇ (y ◇ (x ◇ (y ◇ y)))
 def rule : FreeMagma α → FreeMagma α
-  | m@(.Fork y1 (.Fork y2 (.Fork x (.Fork y3 y4)))) =>
+  | m@(y1 ⋆ (y2 ⋆ (x ⋆ (y3 ⋆ y4)))) =>
       if y1 = y2 ∧ y1 = y3 ∧ y1 = y4 then
         x
       else
@@ -427,7 +417,7 @@ variable [DecidableEq α]
 
 -- equation 1515 := x = (y ◇ y) ◇ (x ◇ (x ◇ x))
 def rule : FreeMagma α → FreeMagma α
-  | m@(.Fork (.Fork y1 y2) (.Fork x (.Fork x1 x2))) =>
+  | m@((y1 ⋆ y2) ⋆ (x ⋆ (x1 ⋆ x2))) =>
       if y1 = y2 ∧ x = x1 ∧ x = x2 then
         x
       else
@@ -485,7 +475,7 @@ theorem rule_yyxxx {α} [DecidableEq α] (x y : FreeMagma α) :
   simp [rule]
 
 @[equational_result]
-theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [1515] [817, 1629, 1832, 1925] := by
+theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [1515] [4590] := by
   use ConfMagma (@rule Nat _), inferInstance
   repeat' apply And.intro
   · rintro ⟨x, hx⟩ ⟨y, hy⟩
@@ -497,5 +487,81 @@ theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [1515] [817, 1629, 183
 
 end rw1515
 
+
+namespace rw2038
+
+variable [DecidableEq α]
+
+-- equation 2038 := x = ((x ◇ x) ◇ x) ◇ (y ◇ y)
+def rule : FreeMagma α → FreeMagma α
+  | m@(((x ⋆ x1) ⋆ x2) ⋆ (y1 ⋆ y2)) =>
+      if y1 = y2 ∧ x = x1 ∧ x = x2 then
+        x
+      else
+        m
+  | m => m
+
+instance rule_projection : IsProj (@rule α _) where
+  proj := by
+    intro x
+    unfold rule
+    split
+    · split
+      · right; left; right; left; right; left; rfl
+      · rfl
+    · rfl
+
+@[simp]
+theorem rule_yy (y : FreeMagma α) : rule (y ⋆ y) = y ⋆ y := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨rfl, heq⟩ := heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨rfl, heq⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rule_xyy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule ((y ⋆ y) ⋆ x) = (y ⋆ y) ⋆ x := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨⟨rfl, rfl⟩, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, heq⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · rfl
+  · rfl
+
+@[simp]
+theorem rule_xxxyy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule (((x ⋆ x) ⋆ x) ⋆ (y ⋆ y)) = x := by
+  simp [rule]
+
+@[equational_result]
+theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [2038] [4270] := by
+  use ConfMagma (@rule Nat _), inferInstance
+  repeat' apply And.intro
+  · rintro ⟨x, hx⟩ ⟨y, hy⟩
+    simp [Magma.op]
+    apply Subtype.ext
+    simp only
+    simp [bu, hx, hy]
+  all_goals refute
+
+end rw2038
 
 end Confluence

--- a/equational_theories/Confluence.lean
+++ b/equational_theories/Confluence.lean
@@ -845,5 +845,97 @@ theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [3150] [411, 1426, 203
 
 end rw3150
 
+namespace rw1110
+
+variable [DecidableEq α]
+
+-- equation 1110 := x = y ◇ ((y ◇ (x ◇ x)) ◇ y)
+def rule : FreeMagma α → FreeMagma α
+  | m@(y1 ⋆ ((y2 ⋆ (x ⋆ x1)) ⋆ y3)) =>
+      if y1 = y2 ∧ y1 = y3 ∧ x = x1 then
+        x
+      else
+        m
+  | m => m
+
+instance rule_projection : IsProj (@rule α _) where
+  proj := by
+    intro x
+    unfold rule
+    split
+    · split
+      · right; right; right; left; right; right; right; left; rfl
+      · rfl
+    · rfl
+
+@[simp]
+theorem rule_yy (y : FreeMagma α) : rule (y ⋆ y) = y ⋆ y := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨heq, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, rfl, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · simp [heq]
+  · rfl
+
+@[simp]
+theorem rule_yxx {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule (y ⋆ (x ⋆ x)) = y ⋆ (x ⋆ x) := by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨rfl, rfl, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨rfl, heq, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+    · rfl
+  · rfl
+
+@[simp]
+theorem rule_yxxy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule ((y ⋆ (x ⋆ x)) ⋆ y) = (y ⋆ (x ⋆ x)) ⋆ y:= by
+  unfold rule
+  split
+  · rename_i m2' y1 x y2 y3 y4 heq
+    simp only [Fork.injEq] at heq
+    obtain ⟨rfl, rfl⟩ := heq
+    split
+    · exfalso
+      rename_i hys
+      obtain ⟨_, heq, rfl⟩ := hys
+      have := congrArg FreeMagma.length heq
+      simp [FreeMagma.length] at this
+      have := FreeMagma.length_pos x
+      omega
+    · rfl
+  · rfl
+
+@[simp]
+theorem rule_yyxxy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule (y ⋆ ((y ⋆ (x ⋆ x)) ⋆ y)) = x := by
+  simp [rule]
+
+@[equational_result]
+theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [1110] [8, 411, 1629, 1832, 3253, 3319, 3862, 3915] := by
+  use ConfMagma (@rule Nat _), inferInstance
+  repeat' apply And.intro
+  · rintro ⟨x, hx⟩ ⟨y, hy⟩
+    simp [Magma.op]
+    apply Subtype.ext
+    simp only
+    simp [bu, hx, hy]
+  all_goals refute
+
+end rw1110
 
 end Confluence

--- a/equational_theories/Confluence.lean
+++ b/equational_theories/Confluence.lean
@@ -123,19 +123,19 @@ def ConfMagma := {x : FreeMagma α // bu rw x = x }
 instance : Coe α (ConfMagma rw) where
   coe x := ⟨x, by rfl⟩
 
-instance instMagmaMagma477 : Magma (ConfMagma rw) where
+instance : Magma (ConfMagma rw) where
   op := fun x y => ⟨bu rw (x.1 ◇ y.1), bu_idem rw _⟩
 
 instance [DecidableEq α] : DecidableEq (ConfMagma rw) :=
   inferInstanceAs (DecidableEq {x : FreeMagma α // bu rw x = x })
 
 
-section rw477
+namespace rw477
 
 variable [DecidableEq α]
 
 -- equation 477 := x = y ◇ (x ◇ (y ◇ (y ◇ y)))
-def rw477 : FreeMagma α → FreeMagma α
+def rule : FreeMagma α → FreeMagma α
   | m@(.Fork y1 (.Fork x (.Fork y2 (.Fork y3 y4)))) =>
       if y1 = y2 ∧ y1 = y3 ∧ y1 = y4 then
         x
@@ -143,10 +143,10 @@ def rw477 : FreeMagma α → FreeMagma α
         m
   | m => m
 
-instance rw477_projection : IsProj (@rw477 α _) where
+instance rule_projection : IsProj (@rule α _) where
   proj := by
     intro x
-    unfold rw477
+    unfold rule
     split
     · split
       · right; right; right; left; rfl
@@ -154,8 +154,8 @@ instance rw477_projection : IsProj (@rw477 α _) where
     · rfl
 
 @[simp]
-theorem rw477_yy (y : FreeMagma α) : rw477 (y ⋆ y) = y ⋆ y := by
-  unfold rw477
+theorem rule_yy (y : FreeMagma α) : rule (y ⋆ y) = y ⋆ y := by
+  unfold rule
   split
   · rename_i m2' y1 x y2 y3 y4 heq
     simp only [Fork.injEq] at heq
@@ -172,9 +172,9 @@ theorem rw477_yy (y : FreeMagma α) : rw477 (y ⋆ y) = y ⋆ y := by
   · rfl
 
 @[simp]
-theorem rw477_yyy {α} [DecidableEq α] (y : FreeMagma α) :
-    rw477 (y ⋆ (y ⋆ y)) = y ⋆ (y ⋆ y) := by
-  unfold rw477
+theorem rule_yyy {α} [DecidableEq α] (y : FreeMagma α) :
+    rule (y ⋆ (y ⋆ y)) = y ⋆ (y ⋆ y) := by
+  unfold rule
   split
   · rename_i m2' y1 x y2 y3 y4 heq
     simp only [Fork.injEq] at heq
@@ -189,9 +189,9 @@ theorem rw477_yyy {α} [DecidableEq α] (y : FreeMagma α) :
   · rfl
 
 @[simp]
-theorem rw477_xyyy {α} [DecidableEq α] (x y : FreeMagma α) :
-    rw477 (x ⋆ (y ⋆ (y ⋆ y))) = x ⋆ (y ⋆ (y ⋆ y)) := by
-  unfold rw477
+theorem rule_xyyy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule (x ⋆ (y ⋆ (y ⋆ y))) = x ⋆ (y ⋆ (y ⋆ y)) := by
+  unfold rule
   split
   · rename_i m2' y1 x y2 y3 y4 heq
     simp only [Fork.injEq] at heq
@@ -206,14 +206,14 @@ theorem rw477_xyyy {α} [DecidableEq α] (x y : FreeMagma α) :
   · rfl
 
 @[simp]
-theorem rw477_yxyyy {α} [DecidableEq α] (x y : FreeMagma α) :
-    rw477 (y ⋆ (x ⋆ (y ⋆ (y ⋆ y)))) = x := by
-  simp [rw477]
+theorem rule_yxyyy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule (y ⋆ (x ⋆ (y ⋆ (y ⋆ y)))) = x := by
+  simp [rule]
 
 @[equational_result]
-theorem Equation477_Facts :
+theorem «Facts» :
   ∃ (G : Type) (_ : Magma G), Facts G [477] [1426, 1519, 2035, 2128, 3050, 3150] := by
-  use ConfMagma (@rw477 Nat _), inferInstance
+  use ConfMagma (@rule Nat _), inferInstance
   repeat' apply And.intro
   · rintro ⟨x, hx⟩ ⟨y, hy⟩
     simp [Magma.op]
@@ -247,15 +247,12 @@ theorem Equation477_Facts :
 
 end rw477
 
-
-
-
-section rw467
+namespace rw467
 
 variable [DecidableEq α]
 
 -- equation 467 := x = y ◇ (x ◇ (x ◇ (y ◇ y)))
-def rw467 : FreeMagma α → FreeMagma α
+def rule : FreeMagma α → FreeMagma α
   | m@(.Fork y1 (.Fork x (.Fork x2 (.Fork y2 y3)))) =>
       if y1 = y2 ∧ y1 = y3 ∧ x = x2 then
         x
@@ -263,10 +260,10 @@ def rw467 : FreeMagma α → FreeMagma α
         m
   | m => m
 
-instance rw467_projection : IsProj (@rw467 α _) where
+instance rule_projection : IsProj (@rule α _) where
   proj := by
     intro x
-    unfold rw467
+    unfold rule
     split
     · split
       · right; right; right; left; rfl
@@ -274,8 +271,8 @@ instance rw467_projection : IsProj (@rw467 α _) where
     · rfl
 
 @[simp]
-theorem rw467_yy (y : FreeMagma α) : rw467 (y ⋆ y) = y ⋆ y := by
-  unfold rw467
+theorem rule_yy (y : FreeMagma α) : rule (y ⋆ y) = y ⋆ y := by
+  unfold rule
   split
   · rename_i m2' y1 x y2 y3 y4 heq
     simp only [Fork.injEq] at heq
@@ -292,9 +289,9 @@ theorem rw467_yy (y : FreeMagma α) : rw467 (y ⋆ y) = y ⋆ y := by
   · rfl
 
 @[simp]
-theorem rw467_xyy {α} [DecidableEq α] (x y : FreeMagma α) :
-    rw467 (x ⋆ (y ⋆ y)) = x ⋆ (y ⋆ y) := by
-  unfold rw467
+theorem rule_xyy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule (x ⋆ (y ⋆ y)) = x ⋆ (y ⋆ y) := by
+  unfold rule
   split
   · rename_i m2' y1 x y2 y3 y4 heq
     simp only [Fork.injEq] at heq
@@ -309,9 +306,9 @@ theorem rw467_xyy {α} [DecidableEq α] (x y : FreeMagma α) :
   · rfl
 
 @[simp]
-theorem rw467_xxyy {α} [DecidableEq α] (x y : FreeMagma α) :
-    rw467 (x ⋆ (x ⋆ (y ⋆ y))) = x ⋆ (x ⋆ (y ⋆ y)) := by
-  unfold rw467
+theorem rule_xxyy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule (x ⋆ (x ⋆ (y ⋆ y))) = x ⋆ (x ⋆ (y ⋆ y)) := by
+  unfold rule
   split
   · rename_i m2' y1 x y2 y3 y4 heq
     simp only [Fork.injEq] at heq
@@ -326,14 +323,13 @@ theorem rw467_xxyy {α} [DecidableEq α] (x y : FreeMagma α) :
   · rfl
 
 @[simp]
-theorem rw467_yxxyy {α} [DecidableEq α] (x y : FreeMagma α) :
-    rw467 (y ⋆ (x ⋆ (x ⋆ (y ⋆ y)))) = x := by
-  simp [rw467]
+theorem rule_yxxyy {α} [DecidableEq α] (x y : FreeMagma α) :
+    rule (y ⋆ (x ⋆ (x ⋆ (y ⋆ y)))) = x := by
+  simp [rule]
 
 @[equational_result]
-theorem Equation467_Facts :
-  ∃ (G : Type) (_ : Magma G), Facts G [467] [2847] := by
-  use ConfMagma (@rw467 Nat _), inferInstance
+theorem «Facts» : ∃ (G : Type) (_ : Magma G), Facts G [467] [2847] := by
+  use ConfMagma (@rule Nat _), inferInstance
   repeat' apply And.intro
   · rintro ⟨x, hx⟩ ⟨y, hy⟩
     simp [Magma.op]
@@ -346,5 +342,7 @@ theorem Equation467_Facts :
     decide
 
 end rw467
+
+-- equation 504 := x = y ◇ (y ◇ (x ◇ (y ◇ y)))
 
 end Confluence

--- a/equational_theories/FreeMagma.lean
+++ b/equational_theories/FreeMagma.lean
@@ -63,4 +63,20 @@ theorem evalInMagma_comp {α β} {G} [Magma G] (f : α → β) (g : β → G) :
   intro x
   induction x <;> simp [fmapFreeMagma, evalInMagma, *]
 
+def length {α : Type} : FreeMagma α → Nat
+  | .Leaf _ => 1
+  | .Fork m1 m2 => FreeMagma.length m1 + FreeMagma.length m2
+
+theorem length_pos {α : Type} : (x : FreeMagma α) → 0 < FreeMagma.length x
+  | .Leaf _ => by simp [FreeMagma.length]
+  | .Fork m1 m2 => by
+    have h1 := FreeMagma.length_pos m1
+    have h2 := FreeMagma.length_pos m2
+    simp [FreeMagma.length]
+    omega
+
+@[simp]
+theorem length_ne_0 {α : Type} (x : FreeMagma α) : FreeMagma.length x ≠ 0 :=
+  Nat.not_eq_zero_of_lt x.length_pos
+
 end FreeMagma

--- a/equational_theories/Generated/Confluence/README.md
+++ b/equational_theories/Generated/Confluence/README.md
@@ -15,4 +15,5 @@ The script generates `confluent_equations.txt`. It checks condition 2 very naive
 we have relatively few equations to check and computers are fast enough.
 
 The file `ManuallySampled.lean` includes the implications that were unknown at the time and
-are covered by these arguments.
+are covered by these arguments. These were since manually proven in lean in
+`Confluence.lean`.


### PR DESCRIPTION
This cleans up the lean setup for confluence-of-single-rule magmas considerably, abstracting over the individual rule as much as possible, and proves all facts from
`equational_theories/Generated/Confluence/ManuallySampled.lean`, and also 1110.
