### PR TITLE
comment out MagmaLawExt.addEntry call that majorly slows down the build

### DIFF
--- a/equational_theories/EquationsCommand.lean
+++ b/equational_theories/EquationsCommand.lean
@@ -90,8 +90,8 @@ elab mods:declModifiers tk:"equation " i:num " := " tsyn:term : command => do
   elabCommand (← `(command| abbrev%$tk $thmName : ∀ (G : Type _) [$inst : Magma G], G ⊧ $lawIdent ↔ $eqIdent G :=
                     fun G _ ↦ Iff.trans (Law.satisfies_fin_satisfies_nat G $finLawIdent).symm ($finThmName G)))
   -- register the law
-  modifyEnv (magmaLawExt.addEntry · (lawName, ← (mkNatMagmaLaw lawName).run
-    { env := (← getEnv), opts := (← getOptions) }))
+  --modifyEnv (magmaLawExt.addEntry · (lawName, ← (mkNatMagmaLaw lawName).run
+  --  { env := (← getEnv), opts := (← getOptions) }))
   Command.liftTermElabM do
     -- TODO: This will go wrong if we are in a namespace. Is this really needed, or is there
     -- a way to pass the current position already to the `(command|` above?

--- a/equational_theories/EquationsCommand.lean
+++ b/equational_theories/EquationsCommand.lean
@@ -90,6 +90,8 @@ elab mods:declModifiers tk:"equation " i:num " := " tsyn:term : command => do
   elabCommand (← `(command| abbrev%$tk $thmName : ∀ (G : Type _) [$inst : Magma G], G ⊧ $lawIdent ↔ $eqIdent G :=
                     fun G _ ↦ Iff.trans (Law.satisfies_fin_satisfies_nat G $finLawIdent).symm ($finThmName G)))
   -- register the law
+  -- (The following two lines have been commented out because they cause the build to become very slow.
+  -- See https://github.com/teorth/equational_theories/issues/464.)
   --modifyEnv (magmaLawExt.addEntry · (lawName, ← (mkNatMagmaLaw lawName).run
   --  { env := (← getEnv), opts := (← getOptions) }))
   Command.liftTermElabM do


### PR DESCRIPTION
#427 has caused builds to become much slower.
If I comment out two lines that it added, as in this PR, build times become reasonable again.
This is a stopgap until we understand the source of the slowness.