### PR TITLE
Experiment: speed up decideFin! by optimizing terms

### DIFF
--- a/equational_theories/DecideBang.lean
+++ b/equational_theories/DecideBang.lean
@@ -1,4 +1,7 @@
 import Lean
+import equational_theories.RSimpSet
+import equational_theories.Magma
+import equational_theories.MemoFinOp
 
 /-!
 This module defines variants of the `decide` tactic with various hacks to speed up elaboration.
@@ -69,6 +72,9 @@ private partial def inferDecideFin (p : Expr) : MetaM Expr := do
     | _ => throwError "Unsupported proposition {p}"
 
 
+theorem of_opt_decide_eq_true {p : Prop} [inst : Decidable p] (c : Bool) (h : decide p = c)
+  : c = true → p := by cases h; exact of_decide_eq_true
+
 /-!
 Like `decide!`, but only supports goals that are conjunctions of (possibly negations of) goals
 of the form `∀ (x … z : Fin n), lhs = rhs`.
@@ -82,7 +88,107 @@ elab "decideFin!" : tactic => do
     let expectedTypes := splitConjs expectedType
     let proofs ← expectedTypes.mapM fun expectedType => do
       let s ← inferDecideFin expectedType
+      let decE := mkApp2 (mkConst ``decide) expectedType s
+      let .some se ← getSimpExtension? `rsimp | throwError "simp set rsimp not found"
+      let ctx := { config := {}, simpTheorems := #[(← se.getTheorems)], congrTheorems := (← Meta.getSimpCongrTheorems) }
+      let (res, _stats) ← simp decE ctx
+      let optE := res.expr
+      let optPrf ← res.getProof
       let rflPrf ← mkEqRefl (toExpr true)
-      return mkApp3 (Lean.mkConst ``of_decide_eq_true) expectedType s rflPrf
+      return mkApp5 (Lean.mkConst ``of_opt_decide_eq_true) expectedType s optE optPrf rflPrf
     let proof ← proofs.pop.foldrM (mkAppM ``And.intro #[·, ·]) proofs.back
     return proof
+
+-- Setup to optimze the kind of terms we evaluate
+
+def Fin.all {n : Nat} (P : ∀ i < n, Bool) : Bool := go n (Nat.le_refl n)
+  where
+  go := Nat.rec
+    (motive := fun i => i ≤ n → Bool)
+    (fun _ => true)
+    (fun i ih p => P i (by omega) && ih (by omega))
+
+def Nat.all_below (n : Nat) (P : Nat → Bool) : Bool :=
+  Nat.rec true (fun i ih => P i && ih) n
+
+@[rsimp]
+def Fin.all_eq_all_below {n : Nat} (P : ∀ i < n, Bool) (P' : Nat → Bool)
+  (hP : ∀  i h, P i h = P' i) : Fin.all P = Nat.all_below n P' := by
+  suffices ∀ i (h : i ≤ n), Fin.all.go P i h = Nat.all_below i P'
+    by apply this
+  intros i h
+  induction i
+  case zero => rfl
+  case succ i ih =>
+    simp [all.go, Nat.all_below]
+    congr
+    · apply hP
+    · apply ih
+
+
+theorem Bool.eq_of_eq_true_iff_eq_true {a b : Bool} : (a = true ↔ b = true) → a = b := by
+  cases a; cases b
+  all_goals simp
+
+@[rsimp]
+theorem Fin.decideAll_to_Fin.all {n : Nat} {P : Fin n → Prop} [DecidablePred P] :
+    decide (∀ x, P x) = Fin.all (fun i h => decide (P ⟨i, h⟩)) := by
+  apply Bool.eq_of_eq_true_iff_eq_true
+  simp [Fin.all]
+  suffices ∀ i (h : i ≤ n), (∀ j (hj : j < i), P ⟨j, by omega⟩) = all.go (fun i h ↦ decide (P ⟨i, h⟩)) i h by
+    rw [← this n (Nat.le_refl n)]
+    exact forall_iff
+  intro i h
+  induction i
+  case a.zero =>
+    simp [all.go]
+    rfl
+  case a.succ i ih =>
+    apply propext
+    calc (∀ (j : Nat) (hj : j < i + 1), P ⟨j, by omega⟩)
+      _ ↔ P ⟨i, h⟩ ∧ (∀ (j : Nat) (hj : j < i), P ⟨j, by omega⟩) := by
+        constructor
+        · exact fun h' => ⟨h' i (by omega), fun j hj => h' j (by omega)⟩
+        · intro h' j hj
+          by_cases j = i
+          · subst j; apply h'.1
+          · apply h'.2 j (by omega)
+      _ ↔ decide (P ⟨i, h⟩) = true ∧ (∀ (j : Nat) (hj : j < i), P ⟨j, by omega⟩) := by simp
+      _ ↔ decide (P ⟨i, h⟩) = true ∧ all.go (fun i h ↦ decide (P ⟨i, h⟩)) i (by omega) = true := by rw [ih]
+      _ ↔ all.go (fun i h ↦ decide (P ⟨i, h⟩)) (i+1) h = true := by simp [all.go]
+
+@[rsimp]
+theorem Fin.decideEq_to_Nat {n : Nat} {x y : Fin n} :
+    decide (x = y) = decide (x.val = y.val) := by
+  simp [Fin.ext_iff]
+
+@[rsimp]
+theorem Nat.decideEq_to_beq {x y : Nat} :
+    decide (x = y) = (Nat.beq x y) := by
+  simp [decide, instDecidableEqNat, Nat.decEq]
+  split
+  · simp [*]
+  · simp [*]
+
+attribute [rsimp] Magma.op MemoFinOp.opOfTable
+
+attribute [rsimp] Nat.decideEq_to_beq
+attribute [rsimp] Fin.val_mul Fin.val_add Mul.mul Fin.mul
+attribute [rsimp] instHAdd instHMul instAddNat instMulNat instHPow instPowNat instNatPowNat
+attribute [rsimp] instHMod Nat.instMod instHDiv Nat.instDiv
+
+
+namespace Example
+def table : Nat := 176572862725894008122698639442158340463570358062018791456284713065412594783123644086682432661794684073102303331486778326370940525772356431236683795848309863276639424307474540043134479302998
+
+abbrev Equation2531 (G: Type _) [Magma G] := ∀ x y : G, x = (y ◇ ((y ◇ x) ◇ x)) ◇ y
+
+@[rsimp]
+def M2 : Magma (Fin 13) where
+  op := MemoFinOp.opOfTable table
+
+theorem Equation2531_M2 : @Equation2531 (Fin 13) M2 := by
+  -- show_term
+  decideFin!
+
+end Example

--- a/equational_theories/MemoFinOp.lean
+++ b/equational_theories/MemoFinOp.lean
@@ -5,7 +5,7 @@ This file defines the macro `memoFinOp` that memoizes a function `f : Fin n → 
 its docstring for more info.
 -/
 
-namespace MemeFinOp
+namespace MemoFinOp
 
 open Lean Meta Elab Term
 
@@ -80,4 +80,4 @@ example :
     memoFinOp f = f := by
   funext a b; revert a b; decide
 
-end MemeFinOp
+end MemoFinOp

--- a/equational_theories/RSimpSet.lean
+++ b/equational_theories/RSimpSet.lean
@@ -1,0 +1,4 @@
+import Lean
+
+-- For DecideBang, but has to be in its own file
+register_simp_attr rsimp

--- a/equational_theories/SmallMagmas.lean
+++ b/equational_theories/SmallMagmas.lean
@@ -29,22 +29,22 @@ All magmas of size 2, up to isomorphism and look at the dual operation.
 -/
 
 /-- `x ◇ y => ⊥` -/
-def Magma2a : Magma (Fin 2) where op := memoFinOp (ofMatrix #[ #[0, 0], #[0, 0] ])
+@[reducible] def Magma2a : Magma (Fin 2) where op := memoFinOp (ofMatrix #[ #[0, 0], #[0, 0] ])
 
 /-- `x ◇ y => x ∧ y` -/
-def Magma2b : Magma (Fin 2) where op := memoFinOp (ofMatrix #[ #[0, 0], #[0, 1] ])
+@[reducible] def Magma2b : Magma (Fin 2) where op := memoFinOp (ofMatrix #[ #[0, 0], #[0, 1] ])
 
 /-- `x ◇ y => x ∧ ¬ y` -/
-def Magma2c : Magma (Fin 2) where op := memoFinOp (ofMatrix #[ #[0, 0], #[1, 0] ])
+@[reducible] def Magma2c : Magma (Fin 2) where op := memoFinOp (ofMatrix #[ #[0, 0], #[1, 0] ])
 
 /-- `x ◇ y => x` -/
-def Magma2d : Magma (Fin 2) where op := memoFinOp (ofMatrix #[ #[0, 0], #[1, 1] ])
+@[reducible] def Magma2d : Magma (Fin 2) where op := memoFinOp (ofMatrix #[ #[0, 0], #[1, 1] ])
 
 /-- `x ◇ y => x ^ y` -/
-def Magma2e : Magma (Fin 2) where op := memoFinOp (ofMatrix #[ #[0, 1], #[1, 0] ])
+@[reducible] def Magma2e : Magma (Fin 2) where op := memoFinOp (ofMatrix #[ #[0, 1], #[1, 0] ])
 
 /-- `x ◇ y = x || y` -/
-def Magma2f : Magma (Fin 2) where op := memoFinOp (ofMatrix #[ #[0, 1], #[1, 1] ])
+@[reducible] def Magma2f : Magma (Fin 2) where op := memoFinOp (ofMatrix #[ #[0, 1], #[1, 1] ])
 
 
 /-- The facts about the first of the magmas (constant 0) -/


### PR DESCRIPTION
Do not merge (yet).

This is an experiment if we can make kernel reduction of the `Fin` counterexamples faster if we optimize the terms for kernel reduction, removing all overhead due to type classes and `Fin`.

Before:
```
$ echo 'def recompileMePlease := 1' >> equational_theories/DecideBang.lean ; time lake build

real	4m56,266s
user	27m4,134s
sys	5m23,516s
```

After:
```
Build completed successfully.

real	5m49,879s
user	32m46,249s
sys	4m42,513s
```

Probably due to many many fast computations where just running it is faster
than optimizing it this way.

(The proofs therein are not very elegant, but I just wanted them done past 11pm…)
