### PR TITLE
faster equation command

### DIFF
--- a/equational_theories/EquationLawConversion.lean
+++ b/equational_theories/EquationLawConversion.lean
@@ -2,119 +2,66 @@ import equational_theories.MagmaLaw
 
 open Law
 
-/-! Zero variables -/
+def FreeMagma.evalBounded {G} [Magma G] (ls : List G) :
+    (m : FreeMagma Nat) → (∀ a, m.Mem a → a < ls.length) → G
+  | a ⋆ b, h => a.evalBounded ls (h · ∘ .inl) ◇ b.evalBounded ls (h · ∘ .inr)
+  | Lf a, h => ls.get ⟨a, h _ rfl⟩
 
-@[simp] theorem Fin0.match_eq (X : Sort _) (f : Fin 0 → X) : Fin.elim0 = f := by
-  funext i
-  cases i
-  contradiction
+def Law.MagmaLaw.evalBounded {G} [Magma G] (ls : List G) :
+    (m : NatMagmaLaw) → (∀ a, m.Mem a → a < ls.length) → Prop
+  | ⟨a, b⟩, h => a.evalBounded ls (h · ∘ .inl) = b.evalBounded ls (h · ∘ .inr)
 
-theorem Fin0.uncurry {X : Type _} (P : (Fin 0 → X) → Prop) : (∀ f : Fin 0 → X, P f) ↔
-    P Fin.elim0 :=
-  ⟨fun h ↦ h _, fun h f ↦ by simpa only [← match_eq]⟩
+def FreeMagma.bounded (n : Nat) : FreeMagma Nat → Bool
+  | a ⋆ b => a.bounded n && b.bounded n
+  | Lf a => a < n
 
-theorem models_iff_0 (law : MagmaLaw (Fin 0)) (G  : Type _) [Magma G] : G ⊧ law ↔
-    satisfiesPhi (Fin.elim0 (α := G)) law := by
-  rw [satisfies, Fin0.uncurry]
+def Law.MagmaLaw.bounded (n : Nat) : NatMagmaLaw → Bool
+  | ⟨a, b⟩ => a.bounded n && b.bounded n
 
-/-! One variable -/
+theorem FreeMagma.bounded_iff {n} {m : FreeMagma Nat} : m.bounded n ↔ ∀ a, m.Mem a → a < n := by
+  induction m <;> simp [bounded, Mem, or_imp, forall_and, *]
 
-@[simp] theorem Fin1.match_eq (X : Sort _) (f : Fin 1 → X) : (fun | 0 => f 0) = f := by
-  funext i
-  match i with
-  | 0 => rfl
+theorem Law.MagmaLaw.bounded_iff {n} {m : NatMagmaLaw} : m.bounded n ↔ ∀ a, m.Mem a → a < n := by
+  cases m; simp [bounded, Mem, or_imp, forall_and, FreeMagma.bounded_iff]
 
-theorem Fin1.uncurry {X : Type _} (P : (Fin 1 → X) → Prop) : (∀ f : Fin 1 → X, P f) ↔
-      ∀ x : X, P (fun | 0 => x) := by
-  refine ⟨fun h _ ↦ h _, fun h f ↦ ?_⟩
-  have := h (f 0)
-  simpa only [match_eq]
+def ModelsIffType (G : Type*) [Magma G] (law : NatMagmaLaw) :
+    (n : Nat) → (ls : List G) → law.bounded (n + ls.length) → Prop
+  | 0, xs, h => law.evalBounded xs.reverse (by simpa using Law.MagmaLaw.bounded_iff.1 h)
+  | n+1, xs, h => ∀ x, ModelsIffType G law n (x::xs) (by rwa [Nat.succ_add] at h)
 
-theorem models_iff_1 (law : MagmaLaw (Fin 1)) (G  : Type _) [Magma G] : G ⊧ law ↔
-    ∀ x : G, satisfiesPhi (fun | 0 => x) law := by
-  rw [satisfies, Fin1.uncurry]
-
-/-! Two variables -/
-
-@[simp] theorem Fin2.match_eq (X : Sort _) (f : Fin 2 → X) : (fun | 0 => f 0 | 1 => f 1) = f := by
-  funext i
-  match i with
-  | 0 | 1 => rfl
-
-theorem Fin2.uncurry {X : Type _} (P : (Fin 2 → X) → Prop) : (∀ f : Fin 2 → X, P f) ↔
-      ∀ x y : X, P (fun | 0 => x | 1 => y) := by
-  refine ⟨fun h _ _ ↦ h _, fun h f ↦ ?_⟩
-  have := h (f 0) (f 1)
-  simpa only [match_eq]
-
-theorem models_iff_2 (law : MagmaLaw (Fin 2)) (G  : Type _) [Magma G] : G ⊧ law ↔
-    ∀ x y : G, satisfiesPhi (fun | 0 => x | 1 => y) law := by
-  rw [satisfies, Fin2.uncurry]
-
-/-! Three variables -/
-
-@[simp] theorem Fin3.match_eq (X : Sort _) (f : Fin 3 → X) : (fun | 0 => f 0 | 1 => f 1 | 2 => f 2) = f := by
-  funext i
-  match i with
-  | 0 | 1 | 2 => rfl
-
-theorem Fin3.uncurry {X : Type _} (P : (Fin 3 → X) → Prop) : (∀ f : Fin 3 → X, P f) ↔
-    ∀ x y z : X, P (fun | 0 => x | 1 => y | 2 => z) := by
-  refine ⟨fun h _ _ _ ↦ h _, fun h f ↦ ?_⟩
-  have := h (f 0) (f 1) (f 2)
-  simpa only [match_eq]
-
-theorem models_iff_3 (law : MagmaLaw (Fin 3)) (G  : Type _) [Magma G] : G ⊧ law ↔
-    ∀ x y z : G, satisfiesPhi (fun | 0 => x | 1 => y | 2 => z) law := by
-  rw [satisfies, Fin3.uncurry]
-
-/-! Four variables -/
-
-@[simp] theorem Fin4.match_eq (X : Sort _) (f : Fin 4 → X) : (fun | 0 => f 0 | 1 => f 1 | 2 => f 2 | 3 => f 3) = f := by
-  funext i
-  match i with
-  | 0 | 1 | 2 | 3 => rfl
-
-theorem Fin4.uncurry {X : Type _} (P : (Fin 4 → X) → Prop) : (∀ f : Fin 4 → X, P f) ↔
-    ∀ x y z w : X, P (fun | 0 => x | 1 => y | 2 => z | 3 => w) := by
-  refine ⟨fun h _ _ _ _ ↦ h _, fun h f ↦ ?_⟩
-  have := h (f 0) (f 1) (f 2) (f 3)
-  simpa only [match_eq]
-
-theorem models_iff_4 (law : MagmaLaw (Fin 4)) (G  : Type _) [Magma G] : G ⊧ law ↔
-    ∀ x y z w : G, satisfiesPhi (fun | 0 => x | 1 => y | 2 => z | 3 => w) law := by
-  rw [satisfies, Fin4.uncurry]
-
-/-! Five variables -/
-
-@[simp] theorem Fin5.match_eq (X : Sort _) (f : Fin 5 → X) : (fun | 0 => f 0 | 1 => f 1 | 2 => f 2 | 3 => f 3 | 4 => f 4) = f := by
-  funext i
-  match i with
-  | 0 | 1 | 2 | 3 | 4 => rfl
-
-theorem Fin5.uncurry {X : Type _} (P : (Fin 5 → X) → Prop) : (∀ f : Fin 5 → X, P f) ↔
-    ∀ x y z w v : X, P (fun | 0 => x | 1 => y | 2 => z | 3 => w | 4 => v) := by
-  refine ⟨fun h _ _ _ _ _ ↦ h _, fun h f ↦ ?_⟩
-  have := h (f 0) (f 1) (f 2) (f 3) (f 4)
-  simpa only [match_eq]
-
-theorem models_iff_5 (law : MagmaLaw (Fin 5)) (G  : Type _) [Magma G] : G ⊧ law ↔
-    ∀ x y z w v : G, satisfiesPhi (fun | 0 => x | 1 => y | 2 => z | 3 => w | 4 => v) law := by
-  rw [satisfies, Fin5.uncurry]
-
-/-! Six variables -/
-
-@[simp] theorem Fin6.match_eq (X : Sort _) (f : Fin 6 → X) : (fun | 0 => f 0 | 1 => f 1 | 2 => f 2 | 3 => f 3 | 4 => f 4 | 5 => f 5) = f := by
-  funext i
-  match i with
-  | 0 | 1 | 2 | 3 | 4 | 5 => rfl
-
-theorem Fin6.uncurry {X : Type _} (P : (Fin 6 → X) → Prop) : (∀ f : Fin 6 → X, P f) ↔
-    ∀ x y z w v u : X, P (fun | 0 => x | 1 => y | 2 => z | 3 => w | 4 => v | 5 => u) := by
-  refine ⟨fun h _ _ _ _ _ _ ↦ h _, fun h f ↦ ?_⟩
-  have := h (f 0) (f 1) (f 2) (f 3) (f 4) (f 5)
-  simpa only [match_eq]
-
-theorem models_iff_6 (law : MagmaLaw (Fin 6)) (G  : Type _) [Magma G] : G ⊧ law ↔
-    ∀ x y z w v u : G, satisfiesPhi (fun | 0 => x | 1 => y | 2 => z | 3 => w | 4 => v | 5 => u) law := by
-  rw [satisfies, Fin6.uncurry]
+theorem models_iff_n (law : NatMagmaLaw) (n) (h : law.bounded n) (G : Type _) [Magma G] :
+    G ⊧ law ↔ ModelsIffType G law n [] h := by
+  suffices ∀ n k (h : law.bounded (n + k)),
+      G ⊧ law ↔ ∀ xs (h' : xs.length = k), ModelsIffType G law n xs (h' ▸ h) by
+    refine (this n 0 h).trans ?_
+    exact ⟨fun H => H [] rfl, fun H xs h => by cases List.length_eq_zero.1 h; assumption⟩
+  intros n k h
+  induction n generalizing k with
+  | succ n ih =>
+    refine (ih (k+1) (by rwa [Nat.succ_add] at h)).trans ?_
+    simp only [ModelsIffType]
+    exact ⟨fun H xs hxs x => H _ (hxs ▸ rfl), fun | H, x::xs, h => H xs (Nat.succ.inj h) x⟩
+  | zero =>
+    simp only [Nat.zero_add, Law.MagmaLaw.bounded_iff] at h
+    rw [← satisfies_pmap_mk _ h, satisfies]
+    let eqv : {xs : List G // xs.length = k} ≃ ({a // a < k} → G) := {
+      toFun := fun ⟨xs, hx⟩ ⟨i, hi⟩ => xs[i]'(hx ▸ hi)
+      invFun := fun f => ⟨List.ofFn fun i => f ⟨i.1, i.2⟩, by simp⟩
+      left_inv := fun ⟨_, _⟩ => by subst k; simp
+      right_inv := fun _ => by simp
+    }
+    let rev : {xs : List G // xs.length = k} ≃ {xs : List G // xs.length = k} := {
+      toFun := fun ⟨xs, hx⟩ => ⟨xs.reverse, by simp [hx]⟩
+      invFun := fun ⟨xs, hx⟩ => ⟨xs.reverse, by simp [hx]⟩
+      left_inv := fun ⟨_, _⟩ => by simp
+      right_inv := fun ⟨_, _⟩ => by simp
+    }
+    simp only [← eqv.forall_congr_right, Equiv.coe_fn_mk, eqv,  ModelsIffType]
+    refine Iff.trans (forall_congr' fun ⟨xs, hx⟩ => ?_)
+      ((rev.forall_congr_right
+        (q := fun xs => law.evalBounded xs.1 (by simpa [xs.2] using h))).symm.trans Subtype.forall)
+    clear eqv rev; subst k
+    have (m : FreeMagma Nat) (h) : m.evalBounded xs h =
+        (m.pmap fun a h' ↦ ⟨a, h a h'⟩) ⬝ (fun x : {a//a<xs.length} ↦ xs.get ⟨x.1, x.2⟩) := by
+      induction m <;> simp [FreeMagma.pmap, FreeMagma.evalInMagma, FreeMagma.evalBounded, *]
+    simp [satisfiesPhi, MagmaLaw.pmap, MagmaLaw.evalBounded, this]

--- a/equational_theories/EquationsCommand.lean
+++ b/equational_theories/EquationsCommand.lean
@@ -3,100 +3,136 @@ import equational_theories.Magma
 import equational_theories.MagmaLaw
 import equational_theories.EquationLawConversion
 
-open Lean Elab Command Law
+open Lean Elab Command Law Qq
 
-def mkNatMagmaLaw (declName : Name) : ImportM NatMagmaLaw := do
-  let { env, opts, .. } ← read
-  IO.ofExcept <| unsafe env.evalConstCheck NatMagmaLaw opts ``NatMagmaLaw declName
+initialize magmaLawExt : TagDeclarationExtension ← mkTagDeclarationExtension
 
-initialize magmaLawExt : PersistentEnvExtension Name (Name × NatMagmaLaw) (Array (Name × NatMagmaLaw)) ←
-  registerPersistentEnvExtension {
-    mkInitial := pure .empty
-    addImportedFn := Array.concatMapM <| Array.mapM <| fun n ↦ do return (n, ← mkNatMagmaLaw n)
-    addEntryFn := Array.push
-    exportEntriesFn := .map Prod.fst
-  }
+def getMagmaLaws : CoreM (Array (Name × NatMagmaLaw)) := do
+  let mut out := #[]
+  for ns in (magmaLawExt.toEnvExtension.getState (← getEnv)).importedEntries do
+    for n in ns do
+      out := out.push (n, ← unsafe evalConstCheck NatMagmaLaw ``NatMagmaLaw n)
+  return out
 
-def getMagmaLaws {M} [Monad M] [MonadEnv M] : M (Array (Name × NatMagmaLaw)) := do
-  return magmaLawExt.getState (← getEnv)
+namespace EquationsCommand
+
+partial def parseFreeMagma : Term → StateT (Array Ident) Option (FreeMagma Nat)
+  | `(($a)) => parseFreeMagma a
+  | `($a ◇ $b) => return (← parseFreeMagma a) ◇ (← parseFreeMagma b)
+  | x => do
+    unless x.raw.isIdent do failure
+    let x : Ident := ⟨x.raw⟩
+    let ids ← get
+    if let some i := ids.findIdx? (· == x) then
+      pure (Lf i)
+    else
+      let i := ids.size
+      modify (·.push x)
+      pure (Lf i)
+
+def parseMagmaLaw : Term → StateT (Array Ident) Option NatMagmaLaw
+  | `($a = $b) => return { lhs := ← parseFreeMagma a, rhs := ← parseFreeMagma b }
+  | _ => failure
+
+def magmaToExpr {u : Level} {G : Q(Type u)} (inst : Q(Magma $G)) (xs : Array Q($G)) :
+    FreeMagma Nat → Q($G)
+  | a ⋆ b => q($(magmaToExpr inst xs a) ◇ $(magmaToExpr inst xs b))
+  | Lf i => xs[i]!
+
+def lawToExpr {u : Level} {G : Q(Type u)} (inst : Q(Magma $G)) (xs : Array Q($G)) :
+    MagmaLaw Nat → Q(Prop)
+  | ⟨a, b⟩ => q($(magmaToExpr inst xs a) = $(magmaToExpr inst xs b))
+
+section -- FIXME: "deriving instance ToExpr for FreeMagma" fails, this is the edited result
+universe u
+
+private def toExprFreeMagma {α} [Lean.ToExpr α] [ToLevel.{u}] : FreeMagma.{u} α → Expr
+  | .Leaf a =>
+    Expr.app (Expr.app (Expr.const `FreeMagma.Leaf [toLevel.{u}]) (toTypeExpr α)) (toExpr a)
+  | .Fork a1 a2 =>
+    Expr.app (Expr.app (Expr.app (Expr.const `FreeMagma.Fork [toLevel.{u}]) (toTypeExpr α))
+      (toExprFreeMagma a1)) (toExprFreeMagma a2)
+
+private instance {α} [Lean.ToExpr α] [ToLevel.{u}] : ToExpr (@FreeMagma.{u} α) where
+  toExpr := toExprFreeMagma.{u}
+  toTypeExpr := Expr.app (Expr.const `FreeMagma [toLevel.{u}]) (toTypeExpr α)
+
+private def toExprMagmaLaw {α} [Lean.ToExpr α] [ToLevel.{u}] : Law.MagmaLaw.{u} α → Expr
+  | ⟨a, a1⟩ =>
+    Expr.app (Expr.app (Expr.app (Expr.const `Law.MagmaLaw.mk [toLevel.{u}])
+      (toTypeExpr α)) (toExpr a)) (toExpr a1)
+
+instance {α} [Lean.ToExpr α] [ToLevel.{u}] : ToExpr (@Law.MagmaLaw.{u} α) where
+  toExpr := toExprMagmaLaw.{u}
+  toTypeExpr := Expr.app (Expr.const `Law.MagmaLaw [toLevel.{u}]) (toTypeExpr α)
+
+end
 
 /--
 For a more concise syntax, but more importantly to speed up elaboration (where type inference
 for each `◇` makes processing this file very slow) we defined custom syntax for defining
 equations, and a custom elaborator that instantiates the instante parameter of `◇`.
 -/
-elab mods:declModifiers tk:"equation " i:num " := " tsyn:term : command => do
-  let G := mkIdent (← MonadQuotation.addMacroScope `G)
-  let inst := mkIdent (← MonadQuotation.addMacroScope `inst)
+elab mods:declModifiers tk:"equation " i:num " := " tsyn:term : command => Command.liftTermElabM do
+  -- TODO: This will go wrong if we are in a namespace.
   let eqName := .mkSimple s!"Equation{i.getNat}"
   let eqStx := mkNullNode #[tk, i]
-  let eqIdent := mkIdentFrom eqStx eqName (canonical := true)
-  let finLawName := .mkSimple s!"FinLaw{i.getNat}"
-  let finLawIdent := mkIdent finLawName
   let lawName := .mkSimple s!"Law{i.getNat}"
-  let lawIdent := mkIdent lawName
-  let finThmName := mkIdent (.str finLawName "models_iff")
-  let thmName := mkIdent (.str lawName "models_iff")
-  let mut is := #[]
-  let t := tsyn.raw
-  -- Collect all identifiers to introduce them as parameters
-  for s in t.topDown do
-    if s.isIdent && !is.contains s then
-      is := is.push s
-  -- Rewrite `◇` to `inst.op` to avoid type class inference
-  let t ← t.rewriteBottomUpM fun s => match s with
-    | `($a ◇ $b) => `($(inst).op $a $b)
-    | _ => pure s
-  -- Assemble term and command
-  let mut t : Term := ⟨t⟩
-  for i in is.reverse do
-    t ← `(∀ $(⟨i⟩) : $G, $t)
-  elabCommand (← `(command| abbrev%$tk $eqIdent ($G : Type _) [$inst : Magma $G] := $t))
-  Command.liftTermElabM do
-    let declMods ← elabModifiers mods
-    let docs := s!"```\nequation {i.getNat} := {← PrettyPrinter.formatTerm tsyn}\n```"
-    let docs := match declMods.docString? with
-      | none => docs
-      | some more => s!"{docs}\n\n---\n{more}"
-    addDocString' (TSyntax.getId eqIdent) docs
-    -- TODO: This will go wrong if we are in a namespace. Is this really needed, or is there
-    -- a way to pass the current position already to the `(command|` above?
-    Lean.addDeclarationRanges eqName {
-      range := ← getDeclarationRange (← getRef)
-      selectionRange := ← getDeclarationRange eqStx }
+  let thmName := .str lawName "models_iff"
+  let some (law, is) := (parseMagmaLaw tsyn).run #[] | throwError "invalid magma law"
+  let declMods ← elabModifiers mods
+  let docs := s!"```\nequation {i.getNat} := {← PrettyPrinter.formatTerm tsyn}\n```"
+  let docs := match declMods.docString? with
+    | none => docs
+    | some more => s!"{docs}\n\n---\n{more}"
+  let ranges := {
+    range := ← getDeclarationRange (← getRef)
+    selectionRange := ← getDeclarationRange eqStx }
+  let addMarkup name := do
+    addDocString' name docs
+    Lean.addDeclarationRanges name ranges
+    _ ← Term.addTermInfo eqStx (← mkConstWithLevelParams name) (isBinder := true)
 
+  -- define equation
+  let u : Level := .param `u
+  let value ← withLocalDeclDQ `G q(Type u) fun G : Q(Type u) => do
+    withLocalDeclQ `inst .instImplicit q(Magma $G) fun inst =>
+    Meta.withLocalDeclsD (is.map fun i => (i.getId, fun _ => pure G)) fun xs => do
+    let e ← Meta.mkForallFVars xs (lawToExpr (G := G) inst xs law)
+    Meta.mkLambdaFVars #[G, inst] e
+  addDecl <| .defnDecl {
+    name := eqName
+    levelParams := [`u]
+    type := q(∀ (G : Type u) [Magma G], Prop)
+    value := value
+    hints := .abbrev
+    safety := .safe
+  }
+  addMarkup eqName
+  have eqConst : Q(∀ (G : Type u) [Magma G], Prop) := .const eqName [u]
 
-  -- Create law
-  let tl := tsyn.raw
-  let tl ← tl.rewriteBottomUpM fun s => match s with
-    | `($a ◇ $b) => `(FreeMagma.Fork $a $b)
-    | `($a = $b) => `(Law.MagmaLaw.mk $a $b)
-    | _ => pure s
-  -- replace identifier `i` with `idx`.
-  let tl ← tl.rewriteBottomUpM fun s =>
-    match is.indexOf? s with
-      | some idx => `(FreeMagma.Leaf $(quote idx.val))
-      | none => pure s
-  let mut tl : Term := ⟨tl⟩
-  let freeMagmaSize := Syntax.mkNumLit (toString is.size)
-  -- define law over `Fin n`
-  elabCommand (← `(command| abbrev%$tk $finLawIdent : Law.MagmaLaw (Fin $freeMagmaSize) := $tl))
-  -- compatibility between the `finLaw` and the original equation
-  let modelsIffLemma : Ident := mkIdent (.mkSimple s!"models_iff_{is.size}")
-  elabCommand (← `(command| abbrev%$tk $finThmName : ∀ (G : Type _) [$inst : Magma G], G ⊧ $finLawIdent ↔ $eqIdent G := $modelsIffLemma $finLawIdent))
-  -- define the actual law over `Nat`
-  elabCommand (← `(command| abbrev%$tk $lawIdent : Law.NatMagmaLaw := $tl))
+  -- define law over `Nat`
+  addDecl <| .defnDecl {
+    name := lawName
+    levelParams := []
+    type := q(Law.NatMagmaLaw)
+    value := toExpr law
+    hints := .opaque
+    safety := .safe
+  }
+  addMarkup lawName
+  have lawConst : Q(Law.NatMagmaLaw) := .const lawName []
+
   -- compatibility between the law and the original equation
-  elabCommand (← `(command| abbrev%$tk $thmName : ∀ (G : Type _) [$inst : Magma G], G ⊧ $lawIdent ↔ $eqIdent G :=
-                    fun G _ ↦ Iff.trans (Law.satisfies_fin_satisfies_nat G $finLawIdent) ($finThmName G)))
+  have n : ℕ := is.size
+  have : Q(MagmaLaw.bounded $n $lawConst = true) := (q(Eq.refl true) : Expr)
+  addDecl <| .thmDecl {
+    name := thmName
+    levelParams := [`u]
+    type := q(∀ (G : Type u) [Magma G], G ⊧ $lawConst ↔ $eqConst G)
+    value := q(models_iff_n.{u} $lawConst $n $this)
+  }
+  addMarkup thmName
+
   -- register the law
-  -- (The following two lines have been commented out because they cause the build to become very slow.
-  -- See https://github.com/teorth/equational_theories/issues/464.)
-  --modifyEnv (magmaLawExt.addEntry · (lawName, ← (mkNatMagmaLaw lawName).run
-  --  { env := (← getEnv), opts := (← getOptions) }))
-  Command.liftTermElabM do
-    -- TODO: This will go wrong if we are in a namespace. Is this really needed, or is there
-    -- a way to pass the current position already to the `(command|` above?
-    Lean.addDeclarationRanges lawName {
-      range := ← getDeclarationRange (← getRef)
-      selectionRange := ← getDeclarationRange (← getRef) }
+  modifyEnv (magmaLawExt.tag · lawName)

--- a/equational_theories/EquationsCommand.lean
+++ b/equational_theories/EquationsCommand.lean
@@ -108,6 +108,7 @@ elab mods:declModifiers tk:"equation " i:num " := " tsyn:term : command => Comma
     hints := .abbrev
     safety := .safe
   }
+  setReducibleAttribute eqName
   addMarkup eqName
   have eqConst : Q(∀ (G : Type u) [Magma G], Prop) := .const eqName [u]
 


### PR DESCRIPTION
There are three main improvements in this implementation:
* The command builds terms directly instead of constructing syntax and re-elaborating it through the regular frontend
* The proof of the `models_iff` theorem is streamlined and also generalized to arbitrary arity instead of proving every arity separately
* The slow persistent env extension is replaced with a TagExtension, on the assumption that we only need to ask for the equations in bulk and do not need to maintain a data structure for fast query.

The result is that it now only takes 30 seconds instead of 2.6 minutes to parse the 4600 equations. Including the effect of #472 it only takes 6 seconds.