### PR TITLE
Raise error on equation number order breaking

### DIFF
--- a/scripts/generate_equation_implication_js.py
+++ b/scripts/generate_equation_implication_js.py
@@ -110,6 +110,7 @@ for file in ["1_999", "1000_1999", "2000_2999", "3000_3999", "4000_4694"]:
     for line in open(f"equational_theories/Equations/Eqns{file}.lean"):
         if ':=' in line:
             N += 1
+            assert str(N) in line
             eqs.append("Equation"+str(N)+"["+line.split(":=")[1].strip()+"]")
 print("var equations = ", eqs);
 


### PR DESCRIPTION
Bug #480 was caused by an equation being removed from AllEquations.lean. This PR makes something like that cause an assert failure which should make that more obvious.

Closes #480