### PR TITLE
Change graphiti layout for unknown edges

### DIFF
--- a/home_page/graphiti/index.html
+++ b/home_page/graphiti/index.html
@@ -706,8 +706,9 @@ digraph G {
             graph_json.unknowns[scc_name]
               .filter((x) => x in scc_to_node_map)
               .forEach((x) => {
-                dotFile += `  ${scc_name} -> ${x} [style="dotted"]\n`;
+                dotFile += `  ${scc_name} -> ${x} [style="dotted",constraint=false]\n`;
               });
+
           }
         }
 


### PR DESCRIPTION
As noted in [1], graphiti could generate graphs where the implication pointed downward in the presence of 'unknown' edges. Explicitly tell graphviz to avoid using those edges in making layout decisions.

Before (note 125 implies 73):
![before](https://github.com/user-attachments/assets/b751f136-8f91-412c-9c92-47fa39241951)

After:
![after](https://github.com/user-attachments/assets/c12f4486-f95f-4990-b2ac-c97166f83462)

[1] https://leanprover.zulipchat.com/#narrow/stream/458659-Equational/topic/Graphiti/near/476308901