### PR TITLE
clean up InfModel_1661.lean a bit

### DIFF
--- a/equational_theories/InfModel_1661.lean
+++ b/equational_theories/InfModel_1661.lean
@@ -35,116 +35,21 @@ private def op_1661_1657 (x : ℕ) (y : ℕ) : ℕ :=
   putting them inside the "have" leads to timeouts in the large case analyses.
 -/
 
-private theorem mod_two_ne_zero_direct (n : ℕ) (h : n % 2 ≠ 0) : n % 2 = 1 := by
-  have h_cases : n % 2 = 0 ∨ n % 2 = 1 := by
-    have h_mod : n % 2 < 2 := Nat.mod_lt n (Nat.zero_lt_succ 1)
-    interval_cases (n % 2)
-    simp_all only [ne_eq, not_true_eq_false]
-    simp_all only [ne_eq, one_ne_zero, not_false_eq_true, Nat.one_lt_ofNat, or_true]
-  cases h_cases with
-  | inl h0 => contradiction
-  | inr h1 => exact h1
+private theorem mod_two_succ_0_1_from (n : ℕ) : n % 2 = 0 → (n + 1) % 2 = 1 := by omega
 
-private theorem mod_two_succ_0_1_from (n : ℕ) : n % 2 = 0 → (n + 1) % 2 = 1 := by
-  intro nm2
-  have nm2' : n % 2 = 0 % 2 := by
-    norm_num
-    exact nm2
-  exact (Nat.add_mod_eq_add_mod_right 1 nm2')
+private theorem mod_two_succ_1_0_from (n : ℕ) : n % 2 = 1 → (n + 1) % 2 = 0 := by omega
 
-private theorem mod_two_succ_1_0_from (n : ℕ) : n % 2 = 1 → (n + 1) % 2 = 0 := by
-  intro nm2
-  have nm2' : n % 2 = 1 % 2 := by
-    norm_num
-    exact nm2
-  exact (Nat.add_mod_eq_add_mod_right 1 nm2')
+private theorem mod_two_pred_0_1_to (n : ℕ) : (n + 1) % 2 = 0 → n % 2 = 1 := by omega
 
-private theorem mod_two_pred_0_1_to (n : ℕ) : (n + 1) % 2 = 0 → n % 2 = 1 := by
-  intro nm2
-  by_cases that : n % 2 = 0
-  · have : (n + 1) % 2 = 1 := mod_two_succ_0_1_from n that
-    simp_all only [one_ne_zero]
-  · simp_all only [ne_eq, Nat.mod_two_ne_zero, implies_true]
+private theorem mod_two_pred_1_0_to (n : ℕ) : (n + 1) % 2 = 1 → n % 2 = 0 := by omega
 
-private theorem mod_two_pred_1_0_to (n : ℕ) : (n + 1) % 2 = 1 → n % 2 = 0 := by
-  intro nm2
-  by_cases that : n % 2 = 0
-  · simp_all only [ne_eq, Nat.mod_two_ne_zero, implies_true, one_ne_zero]
-  · have : n % 2 = 1 := mod_two_ne_zero_direct n that
-    have nm3 : (n + 1) % 2 = 0 := mod_two_succ_1_0_from n this
-    simp_all only [zero_ne_one]
+private theorem mod_two_ne_down_to (n m : ℕ) : (n + 1) % 2 = m % 2 → ¬ n % 2 = m % 2 := by omega
 
-private theorem mod_two_ne_down_to (n m : ℕ) : (n + 1) % 2 = m % 2 → ¬ n % 2 = m % 2 := by
-  intro hyp assm
-  by_cases n0: (n % 2 = 0)
-  · have n1 : (n + 1) % 2 = 1 := mod_two_succ_0_1_from n n0
-    have bad : 0 = 1 := by simp_all only [Nat.add_mod_mod]
-    contradiction
-  · have nz1: (n + 1) % 2 = 1 := by
-      simp_all only [Nat.mod_two_ne_zero]
-    have nz0: n % 2 = 1 := by
-      simp_all only [Nat.mod_two_ne_zero, Nat.add_mod_mod]
-    have ns0 : (n + 1) % 2 = 0 := mod_two_succ_1_0_from n nz0
-    have bad : 0 = 1 := by simp_all only [Nat.add_mod_mod]
-    contradiction
+private theorem mod_two_eq_down_to (n m : ℕ) : (n + 1) % 2 ≠ m % 2 → n % 2 = m % 2 := by omega
 
-private theorem mod_two_eq_down_to (n m : ℕ) : (n + 1) % 2 ≠ m % 2 → n % 2 = m % 2 := by
-  intro hyp
-  by_cases n0: (n % 2 = 0)
-  · have e1 : (n + 1) % 2 = 1 := by
-      simp_all only [ne_eq, Nat.mod_two_ne_zero, implies_true]
-      exact (mod_two_succ_0_1_from n n0)
-    have m2_neq_1 : m % 2 ≠ 1 := by
-      intro assm
-      simp_all only [ne_eq, Nat.mod_two_ne_zero, implies_true, not_true_eq_false]
-    have m2_eq_0 : m % 2 = 0 := by
-      simp_all only [ne_eq, Nat.mod_two_ne_zero, implies_true, Nat.mod_two_ne_one]
-    simp_all only [ne_eq, Nat.mod_two_ne_zero, implies_true, one_ne_zero, not_false_eq_true, zero_ne_one]
+private theorem mod_two_ne_up_from (n m : ℕ) : n % 2 = m % 2 → ¬ (n + 1) % 2 = m % 2 := by omega
 
-  · have n1 : n % 2 = 1 := by
-      simp_all only [ne_eq, Nat.mod_two_ne_zero, implies_true]
-    have n11 : (n + 1) % 2 = 0 := mod_two_succ_1_0_from n n1
-    have m2_neq_0 : m % 2 ≠ 0 := by
-      intro assm
-      simp_all only [ne_eq, Nat.mod_two_ne_zero, implies_true, not_true_eq_false]
-    simp_all only [ne_eq, Nat.mod_two_ne_zero, implies_true, one_ne_zero, not_false_eq_true]
-
-private theorem mod_two_ne_up_from (n m : ℕ) : n % 2 = m % 2 → ¬ (n + 1) % 2 = m % 2 := by
-  intro hyp assm
-  by_cases n0: (n % 2 = 0)
-  · have n1 : (n + 1) % 2 = 1 := mod_two_succ_0_1_from n n0
-    have bad : 0 = 1 := by simp_all only [Nat.add_mod_mod]
-    contradiction
-  · have nz1: (n + 1) % 2 = 1 := by
-      simp_all only [Nat.mod_two_ne_zero]
-    have nz0: n % 2 = 1 := by
-      simp_all only [Nat.mod_two_ne_zero, Nat.add_mod_mod]
-    have ns0 : (n + 1) % 2 = 0 := mod_two_succ_1_0_from n nz0
-    have bad : 0 = 1 := by simp_all only [Nat.add_mod_mod]
-    contradiction
-
-private theorem mod_two_eq_up_from (n m : ℕ) : n % 2 ≠ m % 2 → (n + 1) % 2 = m % 2 := by
-  intro hyp
-  by_cases n0: (n % 2 = 0)
-  · have e1 : (n + 1) % 2 = 1 := by
-      simp_all only [ne_eq, Nat.mod_two_ne_zero, implies_true]
-      exact (mod_two_succ_0_1_from n n0)
-    have m2_eq_1 : m % 2 = 1 := by
-      have : m % 2 ≠ 0 := by
-        rw [← n0]
-        exact (Ne.symm hyp)
-      exact (mod_two_ne_zero_direct m this)
-    simp_all only [ne_eq, zero_ne_one, not_false_eq_true]
-  · have n1 : n % 2 = 1 := by
-      simp_all only [ne_eq, Nat.mod_two_ne_zero, implies_true]
-    have n11 : (n + 1) % 2 = 0 := mod_two_succ_1_0_from n n1
-    have m2_eq_0 : m % 2 = 0 := by
-      have : m %2 ≠ 1 := by
-        rw [← n1]
-        exact (Ne.symm hyp)
-      simp_all only [ne_eq, one_ne_zero, not_false_eq_true, Nat.mod_two_ne_one]
-    simp_all only [ne_eq, one_ne_zero, not_false_eq_true]
-
+private theorem mod_two_eq_up_from (n m : ℕ) : n % 2 ≠ m % 2 → (n + 1) % 2 = m % 2 := by omega
 
 /-
   We prove lemmata about the left (x ⋄ y) and the right ((y ⋄ z) ⋄ y) of
@@ -163,15 +68,15 @@ private def delta_right_even (n : ℕ) : ℕ :=
 
 private theorem op_right_even (y : ℕ) : (y + 5) % 2 = 0 → ∀ (x : ℕ), op_1661_1657 (op_1661_1657 (y + 5) x) (y + 5) = y + delta_right_even x := by
     intro y5e x
-    have y4o : (y + 4) % 2 = 1 := mod_two_pred_0_1_to (y + 4) y5e
-    have y6o : (y + 6) % 2 = 1 := mod_two_succ_0_1_from (y + 5) y5e
+    have y4o : (y + 4) % 2 = 1 := Nat.succ_mod_two_eq_zero_iff.mp y5e
+    have y6o : (y + 6) % 2 = 1 := Nat.succ_mod_two_eq_one_iff.mpr y5e
     match x with
     | 0 | 1 | 2 | 3 | 4 =>
       simp [op_1661_1657,y5e,y4o,y6o,delta_right_even]
     | n+5 =>
       by_cases n5eo : (n + 5) % 2 = 0
       · simp [op_1661_1657,y5e,n5eo,y4o,delta_right_even]
-      · have n5o : (n + 5) % 2 = 1 := mod_two_ne_zero_direct (n + 5) n5eo
+      · have n5o : (n + 5) % 2 = 1 := Nat.mod_two_ne_zero.mp n5eo
         simp [op_1661_1657,y5e,y6o,n5o,delta_right_even]
 
 private def delta_right_odd (n : ℕ) : ℕ :=
@@ -187,15 +92,15 @@ private theorem op_right_odd (y : ℕ) : (y + 5) % 2 ≠ 0 → ∀ (x : ℕ), op
     intro y5o x
     have y5o' : (y + 5) % 2 = 1 := by
       simp_all only [↓reduceIte, ne_eq, Nat.mod_two_ne_zero]
-    have y4e : (y + 4) % 2 = 0 := mod_two_pred_1_0_to (y + 4) y5o'
-    have y6e : (y + 6) % 2 = 0 := mod_two_succ_1_0_from (y + 5) y5o'
+    have y4e : (y + 4) % 2 = 0 := Nat.succ_mod_two_eq_one_iff.mp y5o'
+    have y6e : (y + 6) % 2 = 0 := by omega
     match x with
     | 0 | 1 | 2 | 3 | 4 =>
       simp [op_1661_1657,y5o',y4e,y6e,delta_right_odd]
     | n+5 =>
       by_cases n5eo : (n + 5) % 2 = 0
       · simp [op_1661_1657,y5o',n5eo,y4e,y6e,delta_right_odd]
-      · have n5o : (n + 5) % 2 = 1 := mod_two_ne_zero_direct (n + 5) n5eo
+      · have n5o : (n + 5) % 2 = 1 := Nat.mod_two_ne_zero.mp n5eo
         simp [op_1661_1657,y5o',n5o,y4e,delta_right_odd]
 
 private theorem op_left_eq (x y : ℕ) : (x + 5) % 2 = (y + 5) % 2 → op_1661_1657 (x + 5) (y + 5) = x + 4 := by
@@ -284,7 +189,7 @@ private theorem op_1661_1657_satisfies_1661 :
         mod_two_succ_1_0_from (x + 6) hx6
       simp [hx4, hx5, hx6, hx7]
     · have hx5' : (x + 5) % 2 = 1 :=
-        mod_two_ne_zero_direct (x + 5) hx5
+        Nat.mod_two_ne_zero.mp hx5
       have hx4' : (x + 4) % 2 = 0 :=
         mod_two_pred_1_0_to (x + 4) hx5'
       have hx6' : (x + 6) % 2 = 0 :=
@@ -516,7 +421,7 @@ private theorem op_1661_1657_satisfies_1661 :
         simp [op_1661_1657,h5y]
         simp [h4x,h5x,h6x]
       · have h5y' : (y + 5) % 2 = 1 :=
-          mod_two_ne_zero_direct (y + 5) h5y
+          Nat.mod_two_ne_zero.mp h5y
         have h5x : (x + 5) % 2 = 1 := by
           rw [hxy5]
           exact h5y'
@@ -534,7 +439,7 @@ private theorem op_1661_1657_satisfies_1661 :
           mod_two_succ_1_0_from (x + 5) h5x
         simp [op_1661_1657,h5y,h4x,h5x,h6x]
       · have h5y' : (y + 5) % 2 = 1 :=
-          mod_two_ne_zero_direct (y + 5) h5y
+          Nat.mod_two_ne_zero.mp h5y
         have h5x : (x + 5) % 2 = 0 := by
           simp_all only [Nat.mod_two_ne_one, one_ne_zero, not_false_eq_true]
         have h4x : (x + 4) % 2 = 1 :=
@@ -554,7 +459,7 @@ private theorem op_1661_1657_satisfies_1661 :
           mod_two_pred_0_1_to (x + 4) h5x
         simp [op_1661_1657,h4x,h5x,h5y]
       · have h5y' : (y + 5) % 2 = 1 :=
-          mod_two_ne_zero_direct (y + 5) h5y
+          Nat.mod_two_ne_zero.mp h5y
         have h5x : (x + 5) % 2 = 1 := by
           rw [hxy5]
           exact h5y'
@@ -571,7 +476,7 @@ private theorem op_1661_1657_satisfies_1661 :
           mod_two_succ_0_1_from (x + 6) h6x
         simp [op_1661_1657,h5x,h6x,h7x]
       · have h5y' : (y + 5) % 2 = 1 :=
-          mod_two_ne_zero_direct (y + 5) h5y
+          Nat.mod_two_ne_zero.mp h5y
         have h5x : (x + 5) % 2 = 0 := by
           simp_all only [Nat.mod_two_ne_one, one_ne_zero, not_false_eq_true]
         have h6x : (x + 6) % 2 = 1 :=
@@ -588,10 +493,9 @@ theorem Equation1661_not_implies_Equation1657 :
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩
   use ℕ, magN
   apply And.intro
-  simp [Equation1661]
-  simp [magN,op]
-  exact op_1661_1657_satisfies_1661
-  simp
+  · simp only [Equation1661, magN, op]
+    exact op_1661_1657_satisfies_1661
+  simp only [not_forall]
   exists 0, 1
   simp [magN,op,op_1661_1657]
 
@@ -602,10 +506,9 @@ theorem Equation1661_not_implies_Equation1630 :
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩
   use ℕ, magN
   apply And.intro
-  simp [Equation1661]
-  simp [magN,op]
-  exact op_1661_1657_satisfies_1661
-  simp
+  · simp only [Equation1661, magN, op]
+    exact op_1661_1657_satisfies_1661
+  simp only [not_forall]
   exists 1, 0
   simp [magN,op,op_1661_1657]
 
@@ -616,10 +519,9 @@ theorem Equation1661_not_implies_Equation1833 :
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩
   use ℕ, magN
   apply And.intro
-  simp [Equation1661]
-  simp [magN,op]
-  exact op_1661_1657_satisfies_1661
-  simp
+  · simp only [Equation1661, magN, op]
+    exact op_1661_1657_satisfies_1661
+  simp only [not_forall]
   exists 3, 0
   simp [magN,op,op_1661_1657]
 
@@ -630,10 +532,9 @@ theorem Equation1661_not_implies_Equation1837 :
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩
   use ℕ, magN
   apply And.intro
-  simp [Equation1661]
-  simp [magN,op]
-  exact op_1661_1657_satisfies_1661
-  simp
+  · simp [Equation1661, magN, op]
+    exact op_1661_1657_satisfies_1661
+  simp only [not_forall]
   exists 3, 0
   simp [magN,op,op_1661_1657]
 
@@ -644,10 +545,9 @@ theorem Equation1661_not_implies_Equation1851 :
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩
   use ℕ, magN
   apply And.intro
-  simp [Equation1661]
-  simp [magN,op]
-  exact op_1661_1657_satisfies_1661
-  simp
+  · simp only [Equation1661, magN, op]
+    exact op_1661_1657_satisfies_1661
+  simp only [not_forall]
   exists 0, 3
   simp [magN,op,op_1661_1657]
 
@@ -658,10 +558,9 @@ theorem Equation1661_not_implies_Equation1860 :
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩
   use ℕ, magN
   apply And.intro
-  simp [Equation1661]
-  simp [magN,op]
-  exact op_1661_1657_satisfies_1661
-  simp
+  · simp [Equation1661, magN, op]
+    exact op_1661_1657_satisfies_1661
+  simp only [not_forall]
   exists 0, 3
   simp [magN,op,op_1661_1657]
 
@@ -673,10 +572,9 @@ theorem Equation1661_not_implies_Equation2443 :
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩
   use ℕ, magN
   apply And.intro
-  simp [Equation1661]
-  simp [magN,op]
-  exact op_1661_1657_satisfies_1661
-  simp
+  · simp only [Equation1661,magN, op]
+    exact op_1661_1657_satisfies_1661
+  simp only [not_forall]
   exists 1, 0
   simp [magN,op,op_1661_1657]
 
@@ -687,10 +585,9 @@ theorem Equation1661_not_implies_Equation2467 :
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩
   use ℕ, magN
   apply And.intro
-  simp [Equation1661]
-  simp [magN,op]
-  exact op_1661_1657_satisfies_1661
-  simp
+  · simp only [Equation1661, magN, op]
+    exact op_1661_1657_satisfies_1661
+  simp only [not_forall]
   exists 0, 1
   simp [magN,op,op_1661_1657]
 
@@ -701,10 +598,9 @@ theorem Equation1661_not_implies_Equation3457 :
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩
   use ℕ, magN
   apply And.intro
-  simp [Equation1661]
-  simp [magN,op]
-  exact op_1661_1657_satisfies_1661
-  simp
+  · simp only [Equation1661, magN, op]
+    exact op_1661_1657_satisfies_1661
+  simp only [not_forall]
   exists 1, 0
   simp [magN,op,op_1661_1657]
 
@@ -715,10 +611,9 @@ theorem Equation1661_not_implies_Equation3521 :
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩
   use ℕ, magN
   apply And.intro
-  simp [Equation1661]
-  simp [magN,op]
-  exact op_1661_1657_satisfies_1661
-  simp
+  · simp only [Equation1661, magN, op]
+    exact op_1661_1657_satisfies_1661
+  simp only [not_forall]
   exists 0, 1
   simp [magN,op,op_1661_1657]
 
@@ -729,10 +624,9 @@ theorem Equation1661_not_implies_Equation4268 :
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩
   use ℕ, magN
   apply And.intro
-  simp [Equation1661]
-  simp [magN,op]
-  exact op_1661_1657_satisfies_1661
-  simp
+  · simp only [Equation1661, magN, op]
+    exact op_1661_1657_satisfies_1661
+  simp only [not_forall]
   exists 3, 0
   simp [magN,op,op_1661_1657]
 
@@ -743,9 +637,8 @@ theorem Equation1661_not_implies_Equation4314 :
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩
   use ℕ, magN
   apply And.intro
-  simp [Equation1661]
-  simp [magN,op]
-  exact op_1661_1657_satisfies_1661
-  simp
+  · simp only [Equation1661, magN, op]
+    exact op_1661_1657_satisfies_1661
+  simp only [not_forall]
   exists 0, 3
   simp [magN,op,op_1661_1657]


### PR DESCRIPTION
* Replaces some proofs by `omega`, which works and is very fast on these lemmas.
* Removes some lemmas in favor of already-existing theorems, found by the `exact?` tactic.
* Rewrites some non-terminal `simp` as `simp only`.