### PR TITLE
Fix issue #507

### DIFF
--- a/home_page/implications/index.html
+++ b/home_page/implications/index.html
@@ -28,6 +28,11 @@
       .header .equation-stat { cursor: pointer; }
       .header .equation-stat:hover { background-color: #e0e0e0; }
       .checkbox-container { margin: 10px 0; }
+      #equationCommentary {
+        border: 1px solid black;
+        padding: 5px;
+        margin: 5px;
+      }
 
       .link {
 	  color: #0000EE;

--- a/home_page/implications/script.js
+++ b/home_page/implications/script.js
@@ -76,6 +76,15 @@ function showPage(pageId) {
 let showEquivalences = false;
 let filteredCachedItems = [];
 
+function hideVisibility(elementId) {
+    const element = document.getElementById(elementId);
+    element.style.display = "none";
+}
+function showVisibility(elementId) {
+    const element = document.getElementById(elementId);
+    element.style.display = "block";
+}
+
 function filterEquations() {
     if (showEquivalences) {
         filteredCachedItems = cachedItems;
@@ -247,10 +256,14 @@ function renderImplications(index) {
     }
 
     currentEquationIndex = index;
+    selectedEquation.textContent = equations[index];
     selectedEquation.dataset.index = index;
+
     if (commentary[index+1] === undefined) {
-        selectedEquation.textContent = equations[index];
+        hideVisibility("equationCommentary")
+        equationCommentary.innerHTML = "";
     } else {
+        showVisibility("equationCommentary")
         equationCommentary.innerHTML = commentary[index+1];
     }
 


### PR DESCRIPTION
This change clears commentary between equation transitions in the equation explorer, and also adds some styling to make the commentary visibly distinctive from other elements.

![image](https://github.com/user-attachments/assets/75b66ff7-769a-43d7-87b6-b7232f2da39d)

Closes #507