### PR TITLE
graphiti: Add checkbox for sporadic equations

### DIFF
--- a/home_page/graphiti/index.html
+++ b/home_page/graphiti/index.html
@@ -149,6 +149,17 @@
           >
         </div>
 
+        <div class="checkbox-container">
+          <input
+            type="checkbox"
+            id="show_sporadic_equations"
+            name="show_sporadic_equations"
+          />
+          <label for="show_sporadic_equations"
+            >Show sporadic equations (Equations numbered > 4694)</label
+          >
+        </div>
+
         <button type="submit">Submit</button>
       </form>
 
@@ -532,10 +543,14 @@
 
         let vertices_to_delete = new Set();
 
-        // These mess up rendering now with the unknowns, get rid of them.
-        vertices_to_delete.add(5105)
-        vertices_to_delete.add(28393)
-        vertices_to_delete.add(374794)
+        if (params.show_sporadic_equations != "on") {
+          for (const key of Object.keys(graph_json.node_to_scc_map)) {
+            let eq_num = parseInt(key, 10);
+            if (eq_num > 4694) {
+              vertices_to_delete.add(eq_num);
+            }
+          }
+        }
 
         if (params.max_variables) {
           max_var = Number(params.max_variables);
@@ -691,13 +706,17 @@ digraph G {
           dotFile += `]\n`;
         }
 
+        let implication_edges = 0;
         for (const [v, neighbors] of Object.entries(reduced_graph)) {
           for (const n of neighbors) {
             dotFile += `  ${v} -> ${n} [arrowhead="none"]\n`;
+            implication_edges += 1;
           }
         }
+        console.log(`Implication edge count: ${implication_edges}`);
 
         if (params.show_unknowns_conjectures == "on") {
+          let unknown_edges = 0;
           for (const scc_name of Object.keys(scc_to_node_map)) {
             if (!graph_json.unknowns[scc_name]) {
               continue;
@@ -707,9 +726,10 @@ digraph G {
               .filter((x) => x in scc_to_node_map)
               .forEach((x) => {
                 dotFile += `  ${scc_name} -> ${x} [style="dotted",constraint=false]\n`;
+                unknown_edges += 1;
               });
-
           }
+          console.log(`Unknown edge count: ${unknown_edges}`);
         }
 
         dotFile += "}";

--- a/scripts/graph.rb
+++ b/scripts/graph.rb
@@ -1,4 +1,3 @@
-require 'json'
 require 'set'
 
 class Graph
@@ -25,11 +24,10 @@ class Graph
     graph
   end
 
-  def self.from_json(path)
+  def self.from_json_array(arr)
     graph = Graph.new
-    JSON.parse(File.read(path))["implications"].each { |e|
+    arr.each { |e|
       lhs_eq, rhs_eq = e["lhs"], e["rhs"]
-
       graph.add_edge(lhs_eq[8, lhs_eq.length].to_i, rhs_eq[8, rhs_eq.length].to_i)
     }
 
@@ -233,9 +231,9 @@ class Graph
     closure_graph = Graph.new
     vertices.each do |vertex|
       visited = Hash.new(false)
-      reachable = []
+      reachable = Set.new []
       closure_dfs(vertex, visited, reachable)
-      closure_graph.adj_list[vertex] = Set.new reachable
+      closure_graph.adj_list[vertex] = reachable
     end
     closure_graph
   end


### PR DESCRIPTION
I noticed that sometimes graphiti can generate spurious vertices for sporadic equations. Add a checkbox to allow displaying them, otherwise explicitly filter them (in the correct way.)

Also, clean-up the generate graph script and trivially optimize the closure computation.