### PR TITLE
chore: fix `sys.exit(0)` bug in lean4lean_checker

### DIFF
--- a/scripts/lean4lean_checker/main.py
+++ b/scripts/lean4lean_checker/main.py
@@ -65,7 +65,7 @@ class Lean4LeanChecker():
 
     except Exception as e:
       print(f"Failed to upgrade lean4lean.\n Cause: {e.args}\nCancelling lean4lean check and exiting")
-      exit(0)
+      sys.exit(0)
 
   def remove_old_l4l(self):
     try:


### PR DESCRIPTION
This bug was automatically detected using `pylint`.

Running `pylint` on your code is a fantastic way to catch errors like these early, giving you a head start on any potential review comments from experienced Python developers. Think of it as having a super-efficient code reviewer who never gets tired and only wants to help improve your code!

Plus, since it's a robot, there’s no ego involved—just consistent feedback to help make your Python code cleaner, more error-free, and in line with best practices like PEP-8, the widely accepted official style guide for writing Python code.

```
% pip3 install pylint
% pylint scripts/lean4lean_checker/main.py
```

<details>
<summary>Example output</summary>

```
************* Module lean4lean_checker.main
scripts/lean4lean_checker/main.py:9:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
scripts/lean4lean_checker/main.py:10:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:11:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:12:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:13:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:14:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:15:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:16:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:17:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:18:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:19:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:20:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:23:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
scripts/lean4lean_checker/main.py:24:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:25:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:26:0: W0311: Bad indentation. Found 10 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:27:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:28:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:29:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:30:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:31:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:33:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
scripts/lean4lean_checker/main.py:34:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:35:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:36:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:37:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:38:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:39:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:40:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:41:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:42:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:44:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:47:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:48:0: W0311: Bad indentation. Found 10 spaces, expected 20 (bad-indentation)
scripts/lean4lean_checker/main.py:49:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:50:0: W0311: Bad indentation. Found 10 spaces, expected 20 (bad-indentation)
scripts/lean4lean_checker/main.py:53:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:56:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:59:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:60:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:61:0: W0311: Bad indentation. Found 10 spaces, expected 20 (bad-indentation)
scripts/lean4lean_checker/main.py:62:0: W0311: Bad indentation. Found 10 spaces, expected 20 (bad-indentation)
scripts/lean4lean_checker/main.py:63:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:64:0: W0311: Bad indentation. Found 10 spaces, expected 20 (bad-indentation)
scripts/lean4lean_checker/main.py:66:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:67:0: C0301: Line too long (102/100) (line-too-long)
scripts/lean4lean_checker/main.py:67:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:68:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:70:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
scripts/lean4lean_checker/main.py:71:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:72:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:73:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:74:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:75:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:76:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:77:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:78:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:80:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
scripts/lean4lean_checker/main.py:81:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:82:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:83:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:84:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:85:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:87:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
scripts/lean4lean_checker/main.py:88:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:89:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:90:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:91:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:92:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:93:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:94:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:95:0: C0301: Line too long (104/100) (line-too-long)
scripts/lean4lean_checker/main.py:95:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:96:0: W0311: Bad indentation. Found 8 spaces, expected 16 (bad-indentation)
scripts/lean4lean_checker/main.py:98:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:99:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:100:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:102:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
scripts/lean4lean_checker/main.py:103:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:104:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:105:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:106:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:107:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:108:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:110:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:111:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:112:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:121:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:122:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:123:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:124:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:125:0: W0311: Bad indentation. Found 4 spaces, expected 8 (bad-indentation)
scripts/lean4lean_checker/main.py:126:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:127:0: W0311: Bad indentation. Found 6 spaces, expected 12 (bad-indentation)
scripts/lean4lean_checker/main.py:130:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
scripts/lean4lean_checker/main.py:131:0: W0311: Bad indentation. Found 2 spaces, expected 4 (bad-indentation)
scripts/lean4lean_checker/main.py:1:0: C0114: Missing module docstring (missing-module-docstring)
scripts/lean4lean_checker/main.py:8:0: C0115: Missing class docstring (missing-class-docstring)
scripts/lean4lean_checker/main.py:13:4: C0103: Attribute name "topPath" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:14:4: C0103: Attribute name "l4lSubPath" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:15:4: C0103: Attribute name "l4lBinPath" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:16:4: C0103: Attribute name "lakePath" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:17:4: C0103: Attribute name "l4lBuildPath" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:18:4: C0103: Attribute name "l4lManifest" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:19:4: C0103: Attribute name "repoToolchainPath" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:20:4: C0103: Attribute name "l4lToolchainPath" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:8:0: R0902: Too many instance attributes (11/7) (too-many-instance-attributes)
scripts/lean4lean_checker/main.py:23:2: C0116: Missing function or method docstring (missing-function-docstring)
scripts/lean4lean_checker/main.py:23:2: C0103: Method name "checkToolchainMatch" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:30:4: W0702: No exception type(s) specified (bare-except)
scripts/lean4lean_checker/main.py:26:10: W0719: Raising too general exception: Exception (broad-exception-raised)
scripts/lean4lean_checker/main.py:27:6: C0103: Variable name "l4lToolchain" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:27:21: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
scripts/lean4lean_checker/main.py:28:6: C0103: Variable name "projectToolchain" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:28:25: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
scripts/lean4lean_checker/main.py:23:2: R1710: Either all return statements in a function should return an expression, or none of them should. (inconsistent-return-statements)
scripts/lean4lean_checker/main.py:33:2: C0116: Missing function or method docstring (missing-function-docstring)
scripts/lean4lean_checker/main.py:66:11: W0718: Catching too general exception Exception (broad-exception-caught)
scripts/lean4lean_checker/main.py:36:8: W0719: Raising too general exception: Exception (broad-exception-raised)
scripts/lean4lean_checker/main.py:37:6: R1705: Unnecessary "else" after "return", remove the "else" and de-indent the code inside it (no-else-return)
scripts/lean4lean_checker/main.py:53:8: C0103: Variable name "projectToolchain" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:53:27: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
scripts/lean4lean_checker/main.py:56:8: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
scripts/lean4lean_checker/main.py:59:14: W1510: 'subprocess.run' used without explicitly defining the value for 'check'. (subprocess-run-check)
scripts/lean4lean_checker/main.py:60:8: R1705: Unnecessary "else" after "return", remove the "else" and de-indent the code inside it (no-else-return)
scripts/lean4lean_checker/main.py:66:4: C0103: Variable name "e" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:68:6: R1722: Consider using 'sys.exit' instead (consider-using-sys-exit)
scripts/lean4lean_checker/main.py:70:2: C0116: Missing function or method docstring (missing-function-docstring)
scripts/lean4lean_checker/main.py:76:4: W0702: No exception type(s) specified (bare-except)
scripts/lean4lean_checker/main.py:80:2: C0116: Missing function or method docstring (missing-function-docstring)
scripts/lean4lean_checker/main.py:83:4: W0702: No exception type(s) specified (bare-except)
scripts/lean4lean_checker/main.py:82:6: W1510: 'subprocess.run' used without explicitly defining the value for 'check'. (subprocess-run-check)
scripts/lean4lean_checker/main.py:87:2: C0116: Missing function or method docstring (missing-function-docstring)
scripts/lean4lean_checker/main.py:98:11: W0718: Catching too general exception Exception (broad-exception-caught)
scripts/lean4lean_checker/main.py:91:18: W1510: 'subprocess.run' used without explicitly defining the value for 'check'. (subprocess-run-check)
scripts/lean4lean_checker/main.py:96:8: W0719: Raising too general exception: Exception (broad-exception-raised)
scripts/lean4lean_checker/main.py:98:4: C0103: Variable name "e" doesn't conform to snake_case naming style (invalid-name)
scripts/lean4lean_checker/main.py:98:4: W0612: Unused variable 'e' (unused-variable)
scripts/lean4lean_checker/main.py:102:2: C0116: Missing function or method docstring (missing-function-docstring)
scripts/lean4lean_checker/main.py:112:16: W1510: 'subprocess.run' used without explicitly defining the value for 'check'. (subprocess-run-check)

------------------------------------------------------------------
Your code has been rated at 0.00/10 (previous run: 0.00/10, +0.00)
```
</details>