### PR TITLE
Add Functionality to Equation Explorer to Download Raw Implications Table

### DIFF
--- a/home_page/implications/find_equation_id.js
+++ b/home_page/implications/find_equation_id.js
@@ -10,8 +10,12 @@ function showErrorPopup(message) {
     document.getElementById('errorOverlay').style.display = 'block';
 }
 
-function closeErrorPopup() {
-    document.getElementById('errorOverlay').style.display = 'none';
+function showDownloadPopup() {
+    document.getElementById('downloadOverlay').style.display = 'block';
+}
+
+function closePopup(element_id) {
+    document.getElementById(element_id).style.display = 'none';
 }
 
 function tokenize(expr) {
@@ -234,8 +238,8 @@ function findEquation() {
 
     try {
         // Determine if user entered integer input or equation input
-        if (!isNaN(inputEq) && (eqNum === parseInt(eqNum, 10))){
-            eqNum = parseInt(eqNum, 10) - 1;
+        if (!isNaN(inputEq) && (/^\d+$/.test(inputEq))){
+            eqNum = parseInt(inputEq, 10) - 1;
         }
         else{
             eqNum = findEquationNumber(inputEq)-1;

--- a/home_page/implications/find_equation_id.js
+++ b/home_page/implications/find_equation_id.js
@@ -230,10 +230,17 @@ function findEquationNumber(inputEq) {
 function findEquation() {
     const inputEq = document.getElementById('equationInput').value;
     const resultDiv = document.getElementById('result');
-    
+    let eqNum = 0;
+
     try {
-        const eqNum = findEquationNumber(inputEq)-1;
-        
+        // Determine if user entered integer input or equation input
+        if (!isNaN(inputEq) && (eqNum === parseInt(eqNum, 10))){
+            eqNum = parseInt(eqNum, 10) - 1;
+        }
+        else{
+            eqNum = findEquationNumber(inputEq)-1;
+        }
+
         if (eqNum) {
             renderImplications(eqNum);
             showPage('detailPage');

--- a/home_page/implications/index.html
+++ b/home_page/implications/index.html
@@ -69,7 +69,7 @@
           background-color: rgba(0, 0, 0, 0.5);
           z-index: 1000;
       }
-      .error-popup {
+      .popup {
           position: fixed;
           top: 50%;
           left: 50%;
@@ -110,10 +110,18 @@
       <div id="result"></div>
 
       <div id="errorOverlay" class="overlay">
-        <div class="error-popup">
-          <span class="close-btn" onclick="closeErrorPopup()">&times;</span>
+        <div class="popup">
+          <span class="close-btn" onclick="closePopup('errorOverlay')">&times;</span>
           <h2>Oops! There's an issue with your equation</h2>
           <p id="errorMessage"></p>
+        </div>
+      </div>
+
+      <div id="downloadOverlay" class="overlay">
+        <div class="popup">
+          <span class="close-btn" onclick="closePopup('downloadOverlay')">&times;</span>
+          <h2>Please wait</h2>
+          <p>Your download is being processed...</p>
         </div>
       </div>
 
@@ -124,6 +132,10 @@
       <p>
         Download this table as a CSV File
         <button onclick="downloadEquationListCSV()">Download</button>
+      </p>
+      <p>
+        Download raw implications table
+        <button onclick="downloadRawImplicationsCSV()">Download</button>
       </p>
 
 

--- a/home_page/implications/index.html
+++ b/home_page/implications/index.html
@@ -105,7 +105,7 @@
       <h1>Equation Explorer</h1>
 
 
-      <input type="text" id="equationInput" placeholder="Enter an equation (e.g., x*y=y*x)">
+      <input type="text" id="equationInput" placeholder="Enter equation (e.g. x*y=y*x) or equation number">
       <button onclick="findEquation()">Jump to Equation</button>
       <div id="result"></div>
 
@@ -120,6 +120,10 @@
       <p>
         Why not try proving a random unknown implication?
         <button onclick="randomProof()">I'm Feeling Lucky</button>
+      </p>
+      <p>
+        Download this table as a CSV File
+        <button onclick="downloadEquationListCSV()">Download</button>
       </p>
 
 

--- a/home_page/implications/script.js
+++ b/home_page/implications/script.js
@@ -77,6 +77,30 @@ let filteredCachedItems = [];
 let cachedItems = [];
 let cachedItemElements = [];
 
+function downloadEquationListCSV() {
+    const rows = Array.from(equationList.children);
+    const csv = "\uFEFF" + rows.map((row) => (
+        Array.from(row.children).map(
+            (element) => element.textContent
+        ).join(",")))
+        .join("\n");
+
+        const filename = 'export_explorer_' + new Date().toLocaleDateString() + '.csv';
+        downloadStringAsCSV(csv, filename)
+}
+
+function downloadStringAsCSV(string, filename) {
+        // Export code gathered from https://stackoverflow.com/a/56370447/7059087
+        var link = document.createElement('a');
+        link.style.display = 'none';
+        link.setAttribute('target', '_blank');
+        link.setAttribute('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(string));
+        link.setAttribute('download', filename);
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+}
+
 function showPage(pageId) {
     document.querySelectorAll('.page').forEach(page => page.classList.remove('active'));
     document.getElementById(pageId).classList.add('active');
@@ -379,7 +403,7 @@ function renderImplications(index) {
   }
 
   smallest_magma = smallest_magma_data[index+1]
-  smallestMagmaLink.innerHTML = smallest_magma 
+  smallestMagmaLink.innerHTML = smallest_magma
     ? `<br />(Size of smallest non-trivial magma: ${smallest_magma.length} <a target="_blank" href="${FME_BASE_URL}?magma=${encodeURIComponent(JSON.stringify(smallest_magma))}">(Explore)</a>)`
     : `<br />(Size of smallest non-trivial magma: N/A)`
 
@@ -492,10 +516,10 @@ window.addEventListener('popstate', handleUrlChange);
 document.addEventListener('DOMContentLoaded', function() {
     const timestamp = last_updated.timestamp * 1000; // Convert to milliseconds
     const commitHash = last_updated.commit_hash;
-    
+
     const localDate = new Date(timestamp);
     document.getElementById('lastUpdated').textContent = localDate.toLocaleString();
-    
+
     const commitLink = document.getElementById('commitLink');
     commitLink.href = `https://github.com/teorth/equational_theories/tree/${commitHash}`;
     commitLink.textContent = commitHash.substring(0, 7); // Display first 7 characters of the hash

--- a/home_page/implications/script.js
+++ b/home_page/implications/script.js
@@ -78,6 +78,7 @@ let cachedItems = [];
 let cachedItemElements = [];
 
 function downloadEquationListCSV() {
+    showDownloadPopup();
     const rows = Array.from(equationList.children);
     const csv = "\uFEFF" + rows.map((row) => (
         Array.from(row.children).map(
@@ -85,8 +86,23 @@ function downloadEquationListCSV() {
         ).join(",")))
         .join("\n");
 
-        const filename = 'export_explorer_' + new Date().toLocaleDateString() + '.csv';
-        downloadStringAsCSV(csv, filename)
+    const filename = 'export_explorer_' + new Date().toLocaleDateString() + '.csv';
+    downloadStringAsCSV(csv, filename);
+}
+
+function downloadRawImplicationsCSV() {
+    const text_to_number = {"explicit_proof_true":4, "implicit_proof_true":3,
+        "explicit_conjecture_true":2, "implicit_conjecture_true":1, "unknown":0,
+        "explicit_proof_false":-4, "implicit_proof_false":-3,
+        "explicit_conjecture_false":-2, "implicit_conjecture_false":-1,
+    }
+    showDownloadPopup();
+    const csv = implications.map(
+        (equation) => equation.map(
+            (status) => text_to_number[status]
+        ).join(",")
+    ).join("\n")
+    downloadStringAsCSV(csv, 'export_raw_implications_' + new Date().toLocaleDateString() + '.csv');
 }
 
 function downloadStringAsCSV(string, filename) {


### PR DESCRIPTION
Added button as to resolve: https://github.com/teorth/equational_theories/issues/626

Note that this takes a while to download since its 50MB, as such I refactored the popup code a little bit to make it more modular so it could be used for downloads as well. Also, I realize its inefficient to rematch back to integers but the values are slightly different and wanted to keep it with what was being asked in 626. 

Also provided bugfix for searching by number. Bit of a woopsie on my end typing out the wrong variable names

