### PR TITLE
`FreeMagmaWithLaws` to `LiftingMagmaFamily`

### DIFF
--- a/equational_theories/Completeness.lean
+++ b/equational_theories/Completeness.lean
@@ -156,8 +156,8 @@ theorem Completeness {α} {Γ : Ctx α} {E : MagmaLaw α} (h : Γ ⊧ E) : Nonem
   match Completeness' h with
   | .intro x => .intro (derive_of_derive' x)
 
-def FreeMagmaWithLaws.eval {α G} {Γ : Ctx α} (φ : α → G) [Magma G] (modelsG : G ⊧ Γ) :
-    FreeMagmaWithLaws α Γ → G :=
+def FreeMagmaWithLaws.eval {α β G} {Γ : Ctx α} (φ : β → G) [Magma G] (modelsG : G ⊧ Γ) :
+    FreeMagmaWithLaws β Γ → G :=
   Quotient.lift (evalInMagma φ) (by
     intro a b
     simp only [HasEquiv.Equiv, SetoidOfLaws, RelOfLaws, Nonempty.forall]
@@ -166,8 +166,8 @@ def FreeMagmaWithLaws.eval {α G} {Γ : Ctx α} (φ : α → G) [Magma G] (model
     . exact h
     . exact modelsG)
 
-def FreeMagmaWithLaws.evalHom {α G} {Γ : Ctx α} (φ : α → G) [ginst : Magma G] (modelsG : G ⊧ Γ) :
-    FreeMagmaWithLaws α Γ →◇ G where
+def FreeMagmaWithLaws.evalHom {α β G} {Γ : Ctx α} (φ : β → G) [ginst : Magma G] (modelsG : G ⊧ Γ) :
+    FreeMagmaWithLaws β Γ →◇ G where
   toFun := FreeMagmaWithLaws.eval φ modelsG
   map_op' := by
     simp only [eval, Magma.op, ForkWithLaws, embed]

--- a/equational_theories/LiftingMagmaFamilies.lean
+++ b/equational_theories/LiftingMagmaFamilies.lean
@@ -2,7 +2,7 @@ import equational_theories.MagmaLaw
 import equational_theories.Homomorphisms
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Finsupp.Defs
--- import Mathlib.Algebra.Free
+import equational_theories.Completeness
 
 open Law
 
@@ -104,6 +104,14 @@ instance instLiftingMagmaFamilyRightProj : LiftingMagmaFamily RightProj where
     map_op' := fun _ _ ↦ rfl
   }
   lift_factors := by intros; rfl
+
+instance instLiftingMagmaFamilyFreeMagmaWithLaws {α} (Γ : Ctx α)
+    [∀ α [DecidableEq α], DecidableEq (FreeMagmaWithLaws α Γ)] : LiftingMagmaFamily (FreeMagmaWithLaws · Γ) where
+  instMagma := inferInstance
+  instMagmaDecidableEq := inferInstance
+  ι := fun a ↦ embed Γ (.Leaf a)
+  lift {α} _ f := FreeMagmaWithLaws.evalHom (G := FreeMagmaWithLaws α Γ) f (FreeMagmaWithLaws.isModel α Γ)
+  lift_factors := by intros; ext; rfl
 
 -- TODO: Lifting family FreeMagma
 

--- a/equational_theories/LiftingMagmaFamiliesCounterexamples.lean
+++ b/equational_theories/LiftingMagmaFamiliesCounterexamples.lean
@@ -27,7 +27,7 @@ def Std.HashMap.push {α β} [BEq α] [Hashable α] (map : Std.HashMap α (Array
 def generateNonImplicationsTable : CoreM (Std.HashMap String (Array String) × Std.HashMap String (Array String)) := do
   let eqnThms ← Result.extractEquationalResults
   IO.println s!"Extracted {eqnThms.size} equational results. Generating their closure ..."
-  let closure ← Closure.closure <| eqnThms.map Entry.variant
+  let closure ← Closure.closure (eqnThms.map Entry.variant) (← Closure.getStoredDualityRelations).dualEquations
   IO.println s!"Generated the closure of size {closure.size} ..."
   return closure.foldl (init := (.empty (capacity := 8192), .empty (capacity := 8192))) fun (implMap, nonImplMap) edge ↦
     match edge with


### PR DESCRIPTION
The [two](https://github.com/teorth/equational_theories/blob/main/equational_theories/LiftingMagmaFamilies.lean) [files](https://github.com/teorth/equational_theories/blob/main/equational_theories/LiftingMagmaFamiliesCounterexamples.lean) on lifting magma families set up a framework for automatically generating proofs of non-implications using certain special kinds of magmas as counter-examples.

The definition of a lifting magma family is tailor-made to this specific situation and isn't mathematically interesting or natural; this can make it cumbersome to re-use this framework to generate further proofs of non-implications.

However, it turns out that any FreeMagmaWithLaws that has DecidableEq (decidable equality) on its elements automatically gives rise to a LiftingMagmaFamily. By adding a typeclass instance translating from FreeMagmaWithLaws with DecidableEq to a LiftingMagmaFamily, it becomes possible to generate further proofs of non-implications simply by defining an appropriate FreeMagmaWithLaws, which is a far more natural definition to deal with mathematically.