### PR TITLE
FINITE_MAGMA_EXPLORER: support more operation symbols in Filter

### DIFF
--- a/tools/fme/dist/elm.js
+++ b/tools/fme/dist/elm.js
@@ -6082,14 +6082,18 @@ var $author$project$Main$viewModelInfo = F3(
 	function (table, matcher, mi) {
 		var tmatcher = A3(
 			$elm$core$String$replace,
-			'+',
+			'*',
 			'◇',
-			A2(
-				$elm$core$String$filter,
-				function (x) {
-					return x !== ' ';
-				},
-				matcher));
+			A3(
+				$elm$core$String$replace,
+				'+',
+				'◇',
+				A2(
+					$elm$core$String$filter,
+					function (x) {
+						return x !== ' ';
+					},
+					matcher)));
 		var matching = function (xs) {
 			return (tmatcher === '') ? xs : A2(
 				$elm$core$List$filter,

--- a/tools/fme/src/Main.elm
+++ b/tools/fme/src/Main.elm
@@ -232,7 +232,8 @@ viewModelInfo table matcher mi =
     tmatcher =
       matcher |>
       String.filter (\x -> x /= ' ') |>
-      String.replace "+" "◇"
+      String.replace "+" "◇" |>
+      String.replace "*" "◇"
     matching xs =
       if tmatcher == ""
         then xs


### PR DESCRIPTION
Previously, "+" and "\diamond" were supported as operation symbols in the Filter field.
This minor change adds support for "*" as well, to match the behavior of the Equation Explorer.

This means that e.g. Equation 4512 can now be found using any of the following search queries,

* `x◇(y◇z)=`,
* `x+(y+z)=(x+y)+z`,
* `= (x * y) * z`,

or any combinations or extensions of these.