### PR TITLE
temporarily suspending some conjectures to record FME instructions

### DIFF
--- a/equational_theories/Conjectures.lean
+++ b/equational_theories/Conjectures.lean
@@ -82,7 +82,7 @@ conjecture Equation1518_facts : ∃ (G : Type) (_ : Magma G), Facts G [1518] [47
 -- conjecture Equation854_facts : ∃ (G : Type) (_ : Magma G), Facts G [854] [107, 1248, 1251]
 
 /-- https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/Outstanding.20equations.2C.20v1/near/478094170 -/
--- @[equational_result]
--- conjecture Equation3475_facts : ∃ (G : Type) (_ : Magma G), Facts G [3475] [3659]
+@[equational_result]
+conjecture Equation3475_facts : ∃ (G : Type) (_ : Magma G), Facts G [3475] [3659]
 
 end Conjectures

--- a/equational_theories/Conjectures.lean
+++ b/equational_theories/Conjectures.lean
@@ -70,15 +70,19 @@ conjecture Equation1722_facts : ∃ (G : Type) (_ : Magma G), Facts G [1722] [26
 
 /-- https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/Outstanding.20equations.2C.20v1/near/478059364
 -/
-@[equational_result]
-conjecture Equation3352_facts : ∃ (G : Type) (_ : Magma G), Facts G [3352] [4065]
+-- @[equational_result]
+-- conjecture Equation3352_facts : ∃ (G : Type) (_ : Magma G), Facts G [3352] [4065]
 
 /-- https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/Outstanding.20equations.2C.20v1/near/478083079 -/
 @[equational_result]
 conjecture Equation1518_facts : ∃ (G : Type) (_ : Magma G), Facts G [1518] [47, 614, 817, 3862]
 
+-- /-- https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/Outstanding.20equations.2C.20v1/near/478094170 -/
+-- @[equational_result]
+-- conjecture Equation854_facts : ∃ (G : Type) (_ : Magma G), Facts G [854] [107, 1248, 1251]
+
 /-- https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/Outstanding.20equations.2C.20v1/near/478094170 -/
-@[equational_result]
-conjecture Equation854_facts : ∃ (G : Type) (_ : Magma G), Facts G [854] [107, 1248, 1251]
+-- @[equational_result]
+-- conjecture Equation3475_facts : ∃ (G : Type) (_ : Magma G), Facts G [3475] [3659]
 
 end Conjectures


### PR DESCRIPTION
I found that if I recorded a finite magma counterexample as a conjecture, then Finite Magma Explorer no longer records the instructions on how to PR the counterexample.  I'm therefore temporarily suspending two conjectures to grab the instructions, put them in the relevant issue, and then restore the conjectures.  (It's a hack.)