### PR TITLE
Add support for marking implications with the Finite typeclass

### DIFF
--- a/equational_theories/Closure.lean
+++ b/equational_theories/Closure.lean
@@ -3,21 +3,26 @@ import equational_theories.EquationalResult
 namespace Closure
 open Lean Parser Elab Command
 
+structure GraphEdge where
+  lhs : String
+  rhs : String
+deriving DecidableEq, Hashable, Lean.ToJson, Lean.FromJson
+
 inductive Edge
-  | implication : Implication → Edge
-  | nonimplication : Implication → Edge
-  deriving DecidableEq, Hashable
+  | implication : GraphEdge → Edge
+  | nonimplication : GraphEdge → Edge
+deriving DecidableEq, Hashable
 
 def Edge.isTrue : Edge → Bool
   | .implication _ => true
   | .nonimplication _ => false
 
-def Edge.get : Edge → Implication
+def Edge.get : Edge → GraphEdge
   | .nonimplication x | .implication x => x
 
-def Edge.lhs : Edge → String := Implication.lhs ∘ get
+def Edge.lhs : Edge → String := GraphEdge.lhs ∘ get
 
-def Edge.rhs : Edge → String := Implication.rhs ∘ get
+def Edge.rhs : Edge → String := GraphEdge.rhs ∘ get
 
 inductive Outcome
   /-- the implication has an explicit proof -/
@@ -399,7 +404,7 @@ def DualityRelation.ofFile (path : String) : IO DualityRelation := do
     dualEquations := dualEquations.insert b a
   pure ⟨dualEquations⟩
 
-def DualityRelation.dual (rel : DualityRelation) (imp : Implication) : Option Implication :=
+def DualityRelation.dual (rel : DualityRelation) (imp : GraphEdge) : Option GraphEdge :=
   if isCoreEquationName imp.lhs && isCoreEquationName imp.rhs then
     some ⟨rel.dualEquations.getD imp.lhs imp.lhs, rel.dualEquations.getD imp.rhs imp.rhs⟩
   else

--- a/equational_theories/Closure.lean
+++ b/equational_theories/Closure.lean
@@ -172,7 +172,7 @@ def equationSet (inp : Array EntryVariant) : Std.HashSet String := Id.run do
   let mut eqs : Std.HashSet String := {}
   for imp in inp do
     match imp with
-    | .implication ⟨lhs, rhs⟩ =>
+    | .implication ⟨lhs, rhs, _⟩ =>
       eqs := eqs.insert lhs
       eqs := eqs.insert rhs
     | .facts ⟨satisfied, refuted, _⟩ =>
@@ -195,7 +195,7 @@ def toEdges (inp : Array EntryVariant) : Array Edge := Id.run do
   let mut nonimplies : Array Bitset := Array.mkArray eqs.size (Bitset.mk eqs.size)
   for imp in inp do
     match imp with
-    | .implication ⟨lhs, rhs⟩ =>
+    | .implication ⟨lhs, rhs, _⟩ =>
       edges := edges.push (.implication ⟨lhs, rhs⟩)
     | .facts ⟨satisfied, refuted, _⟩ =>
       for f1 in satisfied do

--- a/equational_theories/EquationalResult.lean
+++ b/equational_theories/EquationalResult.lean
@@ -57,11 +57,11 @@ initialize equationalResultsExtension : SimplePersistentEnvExtension Entry (Arra
 
 def Entry.keepCore (e : Entry) : Option Entry :=
   match e.variant with
-  | .implication { lhs, rhs } =>
+  | .implication ⟨lhs, rhs, _⟩  =>
       if isCoreEquationName lhs && isCoreEquationName rhs
       then some e
       else none
-  | .facts { satisfied, refuted, finite } =>
+  | .facts ⟨satisfied, refuted, finite⟩ =>
       let sat1 := satisfied.filterMap filterCoreEquationName
       let ref1 := refuted.filterMap filterCoreEquationName
       if sat1.isEmpty || ref1.isEmpty then none
@@ -107,10 +107,10 @@ initialize equationalResultAttr : Unit ←
 
        -- Add law theorem as well
        match entry.variant with
-        | .implication  _ =>
+        | .implication imp =>
             let _ ← match info with
               | .thmInfo  (val : TheoremVal) =>
-                 addLawImplicationThm val.type val.name
+                 if !imp.finite then addLawImplicationThm val.type val.name
               | _ => pure ()
         | .unconditional _ =>
             let _ ← match info with
@@ -148,7 +148,7 @@ elab_rules : command
   let rs ← extractTheorems
   for ⟨name, _filename, res, _⟩ in rs do
     match res with
-    | .implication ⟨lhs, rhs⟩ => println! "{name}: {lhs} → {rhs}"
+    | .implication ⟨lhs, rhs, _⟩ => println! "{name}: {lhs} → {rhs}"
     | .facts ⟨satisfied, refuted, _⟩ => println! "{name}: {satisfied} // {refuted}"
     | .unconditional rhs => println! "{name}: {rhs} holds unconditionally"
 

--- a/equational_theories/InfModel.lean
+++ b/equational_theories/InfModel.lean
@@ -18,6 +18,7 @@ namespace InfModel
 /--
 In a finite model `Equation374794` implies `Equation2`, that the model is a subsingleton.
 -/
+@[equational_result]
 theorem Finite.Equation374794_implies_Equation2 (G : Type*) [Magma G] [Finite G] (h : Equation374794 G) :
     Equation2 G := by
   have : ∀ (y z u : G), (y ◇ y) ◇ z = (y ◇ y) ◇ u := by
@@ -40,6 +41,7 @@ theorem Finite.Equation374794_implies_Equation2 (G : Type*) [Magma G] [Finite G]
 /--
 However, `Equation374794` doesn't imply `Equation2`.
 -/
+@[equational_result]
 theorem Equation374794_not_implies_Equation2 : ∃ (G : Type) (_ : Magma G), Equation374794 G ∧ ¬Equation2 G := by
   letI : Magma ℕ+ := { op := fun a b ↦ if a = b then 2^a.val else
     if a = 1 then 3^b.val else
@@ -90,6 +92,7 @@ theorem Equation374794_not_implies_Equation2 : ∃ (G : Type) (_ : Magma G), Equ
     · apply t4
     · convert t4 _ 0
 
+@[equational_result]
 theorem Finite.Equation5093_implies_Equation2 (G : Type*) [Magma G] [Finite G] (h : Equation5093 G) :
     Equation2 G:= by
   intro x y
@@ -114,6 +117,7 @@ theorem Finite.Equation5093_implies_Equation2 (G : Type*) [Magma G] [Finite G] (
     _= x ◇ (x ◇ (x ◇ (y ◇ (x ◇ x)))) := by rw [hhhh]
     _= y := by rw [← h y x x]
 
+@[equational_result]
 theorem Finite.Equation28770_implies_Equation2 (G : Type*) [Magma G] [Finite G] (h : Equation28770 G) :
     Equation2 G := by
   have : ∀ (y z u : G), y ◇ z = y ◇ u := by
@@ -133,6 +137,7 @@ theorem Finite.Equation28770_implies_Equation2 (G : Type*) [Magma G] [Finite G] 
   have z := x
   rw [h x y z, this ((y ◇ y) ◇ y)  x u, ← this ((y ◇ y) ◇ y) u u, ← h]
 
+@[equational_result]
 theorem Equation28770_not_implies_Equation2 : ∃ (G : Type) (_ : Magma G), Equation28770 G ∧ ¬Equation2 G := by
   have : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩
   have : Fact (Nat.Prime 3) := ⟨Nat.prime_three⟩
@@ -417,6 +422,7 @@ theorem Equation28770_not_implies_Equation2 : ∃ (G : Type) (_ : Magma G), Equa
       simp [padicValNat_prime_prime_pow, padicValNat.mul, Nat.pow_mul] at h
     · rw [h4 x y (y ◇ z) hyz]
 
+@[equational_result]
 theorem Finite.Equation3994_implies_Equation3588 (G : Type*) [Magma G] [Finite G] (h : Equation3994 G) :
     Equation3588 G := by
   intro x y z
@@ -482,6 +488,7 @@ theorem Equation3588_not_implies_Equation3994 : ∃ (G : Type) (_ : Magma G), Eq
 
 -- Another Austin pair, this one with only two variables in both equations.
 -- https://leanprover.zulipchat.com/#narrow/stream/458659-Equational/topic/1648.20!.3D.3E.20206/near/476842251
+@[equational_result]
 theorem Finite.Equation206_implies_Equation1648 (G : Type*) [Magma G] [Finite G] (h : Equation206 G) : Equation1648 G := by
   intro x y
   let S : Set G := Set.univ

--- a/scripts/extract_implications.lean
+++ b/scripts/extract_implications.lean
@@ -39,7 +39,7 @@ def generateUnknowns (inp : Cli.Parsed) : IO UInt32 := do
     let rs := rs.map (·.variant)
     let (components, outcomes) ← Closure.outcomes_mod_equiv rs dualityRelation.dualEquations
     let sortedComponents := components.in_order.qsort (fun a b => Closure.ltEquationNames a[0]! b[0]!)
-    let mut unknowns : Array Implication := #[]
+    let mut unknowns : Array GraphEdge := #[]
     for c1 in sortedComponents do
       let i := components[c1]!
       for c2 in sortedComponents do
@@ -51,7 +51,7 @@ def generateUnknowns (inp : Cli.Parsed) : IO UInt32 := do
           else
             unknowns := unknowns.push ⟨c1[0]!, c2[0]!⟩
     if duality then
-      let mut allUnknowns : Std.HashSet Implication := {}
+      let mut allUnknowns : Std.HashSet GraphEdge := {}
       for hi : i in [:components.size] do
         for hj : j in [:components.size] do
           if outcomes[i]![j]!.isNone then
@@ -59,8 +59,8 @@ def generateUnknowns (inp : Cli.Parsed) : IO UInt32 := do
               for rhs in components.in_order[j] do
                 allUnknowns := allUnknowns.insert ⟨lhs, rhs⟩
       let eqsToComponent := components.in_order.map (fun comp => (comp[0]!, comp)) |>.toList |> Std.HashMap.ofList
-      let mut unknownsSet : Std.HashSet Implication := {}
-      let mut uniqueUnknowns : Array Implication := #[]
+      let mut unknownsSet : Std.HashSet GraphEdge := {}
+      let mut uniqueUnknowns : Array GraphEdge := #[]
       for imp in unknowns do
         match dualityRelation.dual imp with
           | none => throw $ IO.userError "No dual found"
@@ -91,8 +91,8 @@ def unknowns : Cmd := `[Cli|
 
 --- Output of the extract_implications executable.
 structure Output where
-  implications : Array Implication
-  nonimplications : Array Implication
+  implications : Array GraphEdge
+  nonimplications : Array GraphEdge
 
 --- Output of the extract_implications outcomes subcommand.
 structure OutputOutcomes where
@@ -107,10 +107,10 @@ structure OutputRaw where
   unconditionals : Array String
 deriving Lean.ToJson, Lean.FromJson
 
-def Implication.asJson (v : Implication) : String := s!"\{\"rhs\":\"{v.rhs}\", \"lhs\":\"{v.lhs}\"}"
+def GraphEdge.asJson (v : GraphEdge) : String := s!"\{\"rhs\":\"{v.rhs}\", \"lhs\":\"{v.lhs}\"}"
 
 def Output.asJson (v : Output) : String :=
-  s!"\{\"nonimplications\":[{",".intercalate (v.nonimplications.map Implication.asJson).toList}],\"implications\":[{",".intercalate (v.implications.map Implication.asJson).toList}]}"
+  s!"\{\"nonimplications\":[{",".intercalate (v.nonimplications.map GraphEdge.asJson).toList}],\"implications\":[{",".intercalate (v.implications.map GraphEdge.asJson).toList}]}"
 
 def generateOutcomes (inp : Cli.Parsed) : IO UInt32 := do
   withExtractedResults inp fun rs dualityRelation => do


### PR DESCRIPTION
#702 added support for Finite non-implications, this add support for Finite implications as well. I update the extract_implications script to always default to 'non-finite' results, and I've verified that the outputs of `lake exe extract_implications` outputs for every subcommand match what they were prior to this change, despite marking a number of Finite results with `@[equational_result]` in this change [modulo the two non-finite theorems I added the attribute to as well.]

Note that reviewing by commit might be slightly easier, as the first and last commits are a trivial update and a simple refactor.