### PR TITLE
fix error in example in section 7.1

### DIFF
--- a/blueprint/src/chapter/infinite_magma_constructions.tex
+++ b/blueprint/src/chapter/infinite_magma_constructions.tex
@@ -22,7 +22,7 @@ for some function $f: G \to G$.  Thus the translations on $G$ become magma isomo
 
 \begin{example}
   Linear magmas $x\op y = ax+by$ on a field $(\mathbb{F},+,-,\cdot,0,1)$ are translation-invariant if $a + b = 1$,
-  since $(\mathbb{F},+,-,0)$ forms an Abelian group, and one can set $f(x) = bx$.
+  since $(\mathbb{F},+,-,0)$ forms an Abelian group, and one can set $f(x) = -ax$.
 \end{example}
 
 Note that if an example of the latter sort suffices to refute the implication between $P$ and $Q$ then


### PR DESCRIPTION
As far as I can tell, Example 2 in [section 7.1](https://teorth.github.io/equational_theories/blueprint/infinite-magma-constructions-chapter.html#a0000000032) does not work out as stated. If we set `f(x) = bx`, then we get
```
y ⋄ x = x + b(x - y)
      = (1 + b)x - by
```
and the equation `a + b = 1` does not help. Possibly `f(x) = -bx` was intended, as then we get
```
y ⋄ x = x - b(x - y)
      = (1 - b)x + by
      = ax + by
```
but that still doesn't quite match the linearity equation `x ⋄ y = ax + by`. To get it to work, we need to use `f(x) = -ax`. Then:

```
y ⋄ x = x - a(x - y)
      = (1 - a)x + ay
      = bx + ay
      = ay + bx
```
