### PR TITLE
add ref to asterix definition in section 7.2

### DIFF
--- a/blueprint/src/chapter/infinite_magma_constructions.tex
+++ b/blueprint/src/chapter/infinite_magma_constructions.tex
@@ -38,7 +38,7 @@ For instance, writing $x = y+h$, we have
 $$ y \op x = x + f(h)$$
 $$ x \op (y \op x) = x + f(h) + f^2(h)$$
 $$ y \op (x \op (y \op x)) = x + f(h) + f^2(h) + f( h + f(h) + f^2(h) )$$
-where $f^2 = f \circ f$, so the Asterix equation for such magmas simplifies to the univariant functional equation
+where $f^2 = f \circ f$, so the Asterix equation (\Cref{eq65}) for such magmas simplifies to the univariant functional equation
 \begin{equation}\label{fh}
    f(h) + f^2(h) + f( h + f(h) + f^2(h) ) = 0
 \end{equation}


### PR DESCRIPTION
[section 7.2](https://teorth.github.io/equational_theories/blueprint/infinite-magma-constructions-chapter.html#asterix-section) mentions the "Asterix equation", but never recalls exactly what that equation is.

This PR adds a `\Cref` back to the [relevant definition](https://teorth.github.io/equational_theories/blueprint/subgraph-eq.html#eq65).

The style of the reference matches other in other chapters, e.g. https://github.com/teorth/equational_theories/blob/70e5481dbe5f931642966892c2cc7dda8cb1b02a/blueprint/src/chapter/constant.tex#L4