### PR TITLE
Graphiti: Add mode to see 'neighborhoods'

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Generate home_page/graphiti/graph.json
         run: |
-          ~/.elan/bin/lake exe extract_implications --json > /tmp/implications.json
+          ~/.elan/bin/lake exe extract_implications --json --only-implications --closure equational_theories > /tmp/implications.json
           ~/.elan/bin/lake exe extract_implications unknowns > /tmp/unknowns.json
           ruby scripts/generate_graphiti_data.rb /tmp/implications.json /tmp/unknowns.json data/duals.json > home_page/graphiti/graph.json
 

--- a/home_page/graphiti/index.html
+++ b/home_page/graphiti/index.html
@@ -117,6 +117,33 @@
         >
         <input type="text" id="implied_by" name="implied_by" /><br />
 
+        <label for="neighborhood_of"
+          >Equation implies/implied by, number of edges away (numeric,
+          comma-separated):</label
+        >
+        <span style="width: 100%; display: flex">
+          <select name="neighborhood_of_distance" id="neighborhood_of_distance">
+            <option value="" selected disabled hidden></option>
+            <option value=""></option>
+            <option value="1">1</option>
+            <option value="2">2</option>
+            <option value="3">3</option>
+            <option value="4">4</option>
+            <option value="5">5</option>
+            <option value="6">6</option>
+            <option value="7">7</option>
+            <option value="8">8</option>
+            <option value="9">9</option>
+            <option value="10">10</option>
+          </select>
+          <input
+            type="text"
+            id="neighborhood_of"
+            name="neighborhood_of"
+            style="margin-left: 8px; width: 50%; flex: 1"
+          /> </span
+        ><br />
+
         <label for="limit_equations"
           >Limit search to equations (numeric, comma-separated):</label
         >
@@ -195,8 +222,15 @@
         <li>
           <a
             href="#"
-            onclick="fillForm({implies: '43', max_variables: '3', highlight_red: '43'})"
-            >Equations up to 3 variables implied by the commutative law</a
+            onclick="fillForm({implies: '43', max_variables: '2', highlight_red: '43'})"
+            >Equations up to 2 variables implied by the commutative law</a
+          >
+        </li>
+        <li>
+          <a
+            href="#"
+            onclick="fillForm({neighborhood_of: '43', neighborhood_of_distance: '2', highlight_red: '43'})"
+            >Implies/implied by of the commutative law up to 2 edges away</a
           >
         </li>
         <li>
@@ -282,6 +316,11 @@
           }
         }
 
+        const selects = form.getElementsByTagName("select");
+        for (let select of selects) {
+          select.selectedIndex = 0;
+        }
+
         // Loop over the keys of the params object and fill the corresponding form fields
         Object.keys(params).forEach((key) => {
           const inputField = form.querySelector(`input[name="${key}"]`);
@@ -290,6 +329,15 @@
               inputField.checked = params[key]; // Set checkbox value
             } else {
               inputField.value = params[key];
+            }
+          } else {
+            // If no input found, attempt to find a select element with the given name
+            const selectField = form.querySelector(`select[name="${key}"]`);
+
+            if (selectField) {
+              if (!selectField.hasAttribute("multiple")) {
+                selectField.value = params[key];
+              }
             }
           }
         });
@@ -508,6 +556,18 @@
         return Array.from(vertices);
       }
 
+      function reverse_graph(adj_list) {
+        let reversed_graph = {};
+        for (let [u, neighbors] of Object.entries(adj_list)) {
+          for (let v of neighbors) {
+            if (reversed_graph[v] === undefined) reversed_graph[v] = [];
+            reversed_graph[v].push(u);
+          }
+        }
+
+        return reversed_graph;
+      }
+
       // Transitive reduction making use of the fact we already have all reachability info for every vertex
       function transitive_reduction_of_closure(adj_list) {
         let reduced_graph = {};
@@ -670,6 +730,64 @@
           for (const scc of vertices(graph)) {
             if (sink_sccs.has(scc)) continue;
             if (!graph[scc] || !graph[scc].some((x) => sink_sccs.has(x))) {
+              scc_to_node_map[scc].forEach((x) => vertices_to_delete.add(x));
+            }
+          }
+        }
+        if (params.neighborhood_of) {
+          let distance = new Number(params.neighborhood_of_distance);
+          if (!params.neighborhood_of_distance) {
+            distance = 100;
+          }
+
+          let targets = parseCommaSeparatedNumbers(params.neighborhood_of);
+          let target_sccs = new Set([
+            ...targets.map((s) => node_to_scc_map[s]),
+          ]);
+
+          // As we only have the graph closure, to do BFS we first make a reduced graph.
+          reduced_graph = transitive_reduction_of_closure(graph);
+
+          function bfs(graph, start_nodes, maxSteps) {
+            const queue = [];
+            const visited = new Set();
+
+            for (n of start_nodes) {
+              queue.push({ node: n, level: 0 });
+              visited.add(n);
+            }
+
+            while (queue.length > 0) {
+              const { node, level } = queue.shift();
+
+              if (level >= maxSteps) {
+                continue;
+              }
+
+              // Iterate through all adjacent nodes
+              const neighbors = graph[node] || [];
+              for (const neighbor of neighbors) {
+                if (!visited.has(neighbor)) {
+                  visited.add(neighbor);
+                  queue.push({ node: neighbor, level: level + 1 });
+                }
+              }
+            }
+
+            return visited;
+          }
+
+          let keep_forward = bfs(reduced_graph, target_sccs, distance);
+          let keep_backward = bfs(
+            reverse_graph(reduced_graph),
+            target_sccs,
+            distance,
+          );
+
+          let keep = new Set([...keep_forward, ...keep_backward]);
+
+          for (const scc of vertices(graph)) {
+            if (!keep.has(scc)) {
               scc_to_node_map[scc].forEach((x) => vertices_to_delete.add(x));
             }
           }

--- a/home_page/implications/script.js
+++ b/home_page/implications/script.js
@@ -425,14 +425,15 @@ function renderImplications(index) {
 	    });
     });
 
-  selectedEquationGraphitiLinks.innerHTML = `<br>(Visualize <a target="_blank" href="${GRAPHITI_BASE_URL}?render=true&implies=${index+1}&highlight_red=${index+1}">implies</a> and <a target="_blank" href="${GRAPHITI_BASE_URL}?render=true&implied_by=${index+1}&highlight_red=${index+1}">implied by</a> of the equation)`
+  const graphiti_url = `${GRAPHITI_BASE_URL}?render=true&highlight_red=${index+1}`
+  selectedEquationGraphitiLinks.innerHTML = `<br>(Visualize <a target="_blank" href="${graphiti_url}&implies=${index+1}">implies</a> and <a target="_blank" href="${graphiti_url}&implied_by=${index+1}">implied by</a> of the equation, or see <a target="_blank" href="${graphiti_url}&neighborhood_of=${index+1}&neighborhood_of_distance=1">1</a>, <a target="_blank" href="${graphiti_url}&neighborhood_of=${index+1}&neighborhood_of_distance=2">2</a>, <a target="_blank" href="${graphiti_url}&neighborhood_of=${index+1}&neighborhood_of_distance=3">3</a> graph edges away)`
   if (unknownImpliesEqNum.length > 0) {
     const implies = unknownImpliesEqNum.map(x => x + 1)
-    selectedEquationGraphitiLinks.innerHTML += `<br />(Visualize <a target="_blank" href="${GRAPHITI_BASE_URL}?render=true&implies=${index+1},${implies.join(",")}&highlight_red=${index+1}&highlight_blue=${implies.join(",")}&show_unknowns_conjectures=on">implies</a> and <a target="_blank" href="${GRAPHITI_BASE_URL}?render=true&implied_by=${index+1},${implies.join(",")}&highlight_red=${index+1}&highlight_blue=${implies.join(",")}&show_unknowns_conjectures=on">implied by</a> of the equation+unknowns+conjectures</a>)`
+    selectedEquationGraphitiLinks.innerHTML += `<br />(Visualize <a target="_blank" href="${graphiti_url}&implies=${index+1},${implies.join(",")}&highlight_blue=${implies.join(",")}&show_unknowns_conjectures=on">implies</a> and <a target="_blank" href="${graphiti_url}&implied_by=${index+1},${implies.join(",")}&highlight_blue=${implies.join(",")}&show_unknowns_conjectures=on">implied by</a> of the equation+unknowns+conjectures</a>)`
   }
   if (unknownImpliedByEqNum.length > 0) {
     const impliedby = unknownImpliedByEqNum.map(x => x + 1)
-    selectedEquationGraphitiLinks.innerHTML += `<br />(Visualize <a target="_blank" href="${GRAPHITI_BASE_URL}?render=true&implies=${index+1},${impliedby.join(",")}&highlight_red=${index+1}&highlight_blue=${impliedby.join(",")}&show_unknowns_conjectures=on">implies</a> and <a target="_blank" href="${GRAPHITI_BASE_URL}?render=true&implied_by=${index+1},${impliedby.join(",")}&highlight_red=${index+1}&highlight_blue=${impliedby.join(",")}&show_unknowns_conjectures=on">implied by</a> of the equation+unknown bys+conjectured bys</a>)`
+    selectedEquationGraphitiLinks.innerHTML += `<br />(Visualize <a target="_blank" href="${graphiti_url}&implies=${index+1},${impliedby.join(",")}&highlight_blue=${impliedby.join(",")}&show_unknowns_conjectures=on">implies</a> and <a target="_blank" href="${graphiti_url}&implied_by=${index+1},${impliedby.join(",")}&highlight_blue=${impliedby.join(",")}&show_unknowns_conjectures=on">implied by</a> of the equation+unknown bys+conjectured bys</a>)`
   }
 
   smallest_magma = smallest_magma_data[index+1]

--- a/scripts/generate_graphiti_data.rb
+++ b/scripts/generate_graphiti_data.rb
@@ -1,4 +1,4 @@
-# lake exe extract_implications --json equational_theories > /tmp/implications.json
+# lake exe extract_implications --json --only-implications --closure equational_theories > /tmp/implications.json
 # lake exe extract_implications unknowns > /tmp/unknowns.json
 # ruby scripts/generate_graphiti_data.rb /tmp/implications.json /tmp/unknowns.json data/duals.json > home_page/graphiti/graph.json
 # python -m http.server 8000 --directory home_page/graphiti
@@ -35,8 +35,6 @@ File.read(File.join(__dir__, '../equational_theories/Equations/Basic.lean')).spl
 implications_graph = Graph.from_json_array(JSON.parse(File.read(ARGV[0]))["implications"])
 condensed_graph, node_to_scc_map, scc_to_node_map = implications_graph.condensation
 
-condensed_closure = condensed_graph.transitive_closure
-
 unknowns = Graph.new
 Graph.from_json_array(JSON.parse(File.read(ARGV[1]))).adj_list.each { |v1, list|
   list.each { |v2|
@@ -64,7 +62,7 @@ scc_to_node_map.keys.each { |k| scc_to_node_map[k].sort! }
 puts JSON.generate({
   "timestamp" => Time.now.utc.to_i,
   "commit_hash" => `git rev-parse HEAD`.chomp,
-  "condensed_graph" => graph2map(condensed_closure),
+  "condensed_graph" => graph2map(condensed_graph),
   "scc_to_node_map" => scc_to_node_map,
   "node_to_scc_map" => node_to_scc_map,
   "equations" => equations,


### PR DESCRIPTION
This change introduces the ability to see all implies/implied bys a given number of edges away, and adds links to the equation explorer to use this feature. Here's an example, 2 edges away from Equation 43:
![graph](https://github.com/user-attachments/assets/2d0c1932-70f4-4321-a5f5-8907637fbcd8)