### PR TITLE
prove LawsComplete by proof term generation

### DIFF
--- a/equational_theories/Equations/LawsComplete.lean
+++ b/equational_theories/Equations/LawsComplete.lean
@@ -27,6 +27,8 @@ example : laws[1000] = Law1001 := rfl
 -/
 def laws : RArray Law.NatMagmaLaw := defineLaws%
 
+theorem laws.wf : laws.WF := by decide
+
 example : laws[1000] = Law1001 := rfl
 
 /-!
@@ -117,7 +119,7 @@ where
     return ⟨lhs', rhs'⟩
 
 /-- Checks whether variables are canonically ordered -/
-def FreeMagma.is_canonical (next : Nat) : FreeMagma Nat → Option Nat
+def FreeMagma.isCanonical (next : Nat) : FreeMagma Nat → Option Nat
   | .Leaf i => do
     if i < next then
       return next
@@ -126,8 +128,8 @@ def FreeMagma.is_canonical (next : Nat) : FreeMagma Nat → Option Nat
     else
       none
   | .Fork l r => do
-    let next' ← l.is_canonical next
-    let next'' ← r.is_canonical next'
+    let next' ← l.isCanonical next
+    let next'' ← r.isCanonical next'
     return next''
 
 /--
@@ -136,27 +138,28 @@ Checks whether a magma law is canonical:
 * `lhs < rhs` (with the exception of `0 ≃ 0`)
 * The symmetric law did not come first
 -/
-def Law.MagmaLaw.is_canonical (l : Law.MagmaLaw Nat) : Bool :=
-  ((l.lhs.is_canonical 0).bind (fun n => l.rhs.is_canonical n)).isSome &&
+def Law.MagmaLaw.isCanonical (l : Law.MagmaLaw Nat) : Bool :=
+  ((l.lhs.isCanonical 0).bind (fun n => l.rhs.isCanonical n)).isSome &&
   (l.lhs.comp l.rhs = .lt || l.lhs = .Leaf 0) &&
   !(l.symm.canonicalize.comp l = .lt)
 
-theorem FreeMagma.canonicalize_is_canonical (m : FreeMagma Nat) (xs : Array Nat) :
-  (FreeMagma.canonicalize.go m xs).run.1.is_canonical xs.size = some (FreeMagma.canonicalize.go m xs).run.2.size := by
+theorem FreeMagma.canonicalize_isCanonical (m : FreeMagma Nat) (xs : Array Nat) :
+    (FreeMagma.canonicalize.go m xs).run.1.isCanonical xs.size =
+    some (FreeMagma.canonicalize.go m xs).run.2.size := by
   induction m generalizing xs with
   | Leaf v =>
     simp only [Id.run, canonicalize.go, bind, StateT.bind, get, getThe, MonadStateOf.get,
       StateT.get, pure, set]
     cases xs.indexOf? v
     case none =>
-      simp [StateT.bind, pure, StateT.pure, set, StateT.set, is_canonical]
+      simp [StateT.bind, pure, StateT.pure, set, StateT.set, isCanonical]
     case some =>
-      simp [StateT.bind, pure, StateT.pure, set, StateT.set, is_canonical]
+      simp [StateT.bind, pure, StateT.pure, set, StateT.set, isCanonical]
   | Fork l r ih1 ih2 =>
     specialize ih1 xs
     specialize ih2 (canonicalize.go l xs).2
-    simp_all [canonicalize.go, bind, StateT.run, Id.run, StateT.bind, pure, StateT.pure, set, StateT.set, is_canonical,
-      bind, StateT.bind]
+    simp_all only [Id.run, isCanonical, bind, pure, Option.bind_some, Option.some_bind,
+      canonicalize.go, StateT.bind, StateT.pure, Option.some.injEq]
     rfl
 
 /-!
@@ -166,169 +169,167 @@ The proofs are rather unpretty; maybe phrasing everything in terms of `Decidable
 have made that easier. But what works works.
 -/
 
-def testNat : Nat → (P : Nat → Bool) → Bool
-  | 0, _   => true
-  | n+1, P => P n && testNat n P
+open Lean Qq
 
-def testAllSplits (s : Nat) (P : Nat → Nat → Bool) : Bool :=
-  testNat (s+1) fun s' => P s' (s-s')
+def TestNat (n : Nat) (P : Nat → Prop) : Prop := ∀ i < n, P i
 
-def testFreeMagmas (s n : Nat) (P : Nat → FreeMagma Nat → Bool) :=
+theorem TestNat.zero {P} : TestNat 0 P := by simp [TestNat]
+theorem TestNat.succ {n P} (h1 : TestNat n P) (h2 : P n) : TestNat (n+1) P := by
+  simpa only [TestNat, Nat.lt_succ_iff_lt_or_eq, or_imp, forall_and, forall_eq, and_true, h2]
+
+def proveTestNat (n : Nat) {P : Q(Nat → Prop)} (hP : (i : Nat) → MetaM Q($P $i)) :
+    MetaM Q(TestNat $n $P) := do
+  match n with
+  | 0 => pure q(TestNat.zero)
+  | n+1 => pure q(TestNat.succ $(← proveTestNat n hP) $(← hP n))
+
+def TestAllSplits (n : Nat) (P : Nat → Nat → Prop) : Prop := ∀ i j, i + j = n → P i j
+def TestAllSplits' (i j : Nat) (P : Nat → Nat → Prop) : Prop :=
+  ∀ i' < i, P i' (j + (i - i'))
+
+theorem TestAllSplits'.zero {n P} : TestAllSplits' 0 n P := by simp [TestAllSplits', *]
+theorem TestAllSplits'.succ {i j P}
+    (h1 : TestAllSplits' i (j+1) P) (h2 : P i (j+1)) : TestAllSplits' (i+1) j P := by
+  simp only [TestAllSplits', Nat.lt_succ_iff_lt_or_eq, or_imp, forall_and, forall_eq,
+    Nat.add_sub_cancel_left] at *
+  exact ⟨fun i' h => by convert h1 i' h using 1; omega, h2⟩
+
+theorem TestAllSplits.start {n P} (h1 : TestAllSplits' n 0 P) (h2 : P n 0) : TestAllSplits n P := by
+  have : ∀ i ≤ n, P i (n - i) := by
+    simpa [TestAllSplits', Nat.le_iff_lt_or_eq, or_imp, forall_and, h2] using h1
+  intro i j eq
+  cases Nat.eq_sub_of_add_eq' eq
+  exact this _ (by omega)
+
+def proveTestAllSplits (n : Nat) {P : Q(Nat → Nat → Prop)} (hP : (i j : Nat) → MetaM Q($P $i $j)) :
+    MetaM Q(TestAllSplits $n $P) := do
+  let rec go (i j : Nat) : MetaM Q(TestAllSplits' $i $j $P) := do
+    match i with
+    | 0 => pure q(TestAllSplits'.zero)
+    | i + 1 => pure q(TestAllSplits'.succ $(← go i (j+1)) $(← hP i (j+1)))
+  pure q(TestAllSplits.start $(← go n 0) $(← hP n 0))
+
+def TestFreeMagmas (s n : Nat) (P : Nat → FreeMagma Nat → Prop) :=
+  ∀ m n', m.forks = s → m.isCanonical n = some n' → P n' m
+
+theorem TestFreeMagmas.zero {n P}
+    (H : TestNat (n+1) fun i => P (if i < n then n else n+1) (.Leaf i))
+    : TestFreeMagmas 0 n P := by
+  intro
+  | .Leaf i, n, _, eq =>
+    simp (config := {contextual := true}) [TestFreeMagmas, TestNat, FreeMagma.isCanonical] at *
+    specialize H i
+    split at eq
+    · simp_all; apply H; omega
+    · split at eq <;> simp_all
+
+theorem TestFreeMagmas.succ {s n P}
+    (H : TestAllSplits s fun s1 s2 =>
+      TestFreeMagmas s1 n fun n l =>
+        TestFreeMagmas s2 n fun n r =>
+          P n (.Fork l r))
+    : TestFreeMagmas (s+1) n P := by
+  intro
+  | .Fork l r, n, hadd =>
+    simp (config := {contextual := true}) [TestFreeMagmas, FreeMagma.isCanonical,
+        TestAllSplits, Option.bind_eq_some, FreeMagma.forks] at *
+    rintro n'' hcan1
+    exact H _ _ hadd _ _ rfl hcan1 _ _ rfl
+
+partial def proveTestFreeMagmas (s n : Nat) (P : Q(Nat → FreeMagma Nat → Prop))
+    (hP : (i : Nat) → FreeMagma Nat → (m : Q(FreeMagma Nat)) → MetaM Q($P $i $m)) :
+    MetaM Q(TestFreeMagmas $s $n $P) := do
   match s with
   | 0 =>
-    testNat (n+1) fun i =>
-      P (if i < n then n else n+1) (.Leaf i)
-  | s+1 =>
-    testAllSplits s fun s1 s2 =>
-      assert! s1 + s2 = s -- Cunning trick to ensure termination!
-      testFreeMagmas s1 n fun n' l =>
-        testFreeMagmas s2 n' fun n'' r =>
-          P n'' (.Fork l r)
+    let h ← proveTestNat (n+1) fun i : Nat => hP (if i < n then n else n+1) (.Leaf i) q(.Leaf $i)
+    pure q(TestFreeMagmas.zero $h)
+  | s + 1 =>
+    let h ← proveTestAllSplits s fun s1 s2 : Nat =>
+      proveTestFreeMagmas s1 n q(fun n l => TestFreeMagmas $s2 n fun n r => $P n (.Fork l r))
+        fun n l l' => proveTestFreeMagmas s2 n q(fun n r => $P n (.Fork $l' r))
+          fun n r r' => hP n (.Fork l r) q(.Fork $l' $r')
+    pure q(TestFreeMagmas.succ $h)
 
-def testLaws (s : Nat) (P : Law.NatMagmaLaw → Bool) :=
-  testAllSplits s fun s1 s2 =>
-    testFreeMagmas s1 0 fun n' l =>
-      testFreeMagmas s2 n' fun _ r =>
-        if l = .Leaf 0 || l.comp r = .lt then
-          let law := ⟨l, r⟩
-          if law.symm.canonicalize.comp law = .lt then
-            true
-          else
-            P law
-        else
-          true
+def TestLawsBody (l r : FreeMagma Nat) (P : Law.NatMagmaLaw → Prop) :=
+  (l ≠ Lf 0 → l.comp r = Ordering.lt) →
+  ¬(l ≃ r).symm.canonicalize.comp (l ≃ r) = .lt → P (l ≃ r)
 
-def testLawsUpto (s : Nat) (P : Law.NatMagmaLaw → Bool) :=
-  testNat (s+1) fun s' => testLaws s' P
+theorem TestLawsBody.mk1 {l r P}
+    (H : (l ≃ r).symm.canonicalize.comp (l ≃ r) = .lt) : TestLawsBody l r P :=
+  fun _ h => h.elim H
 
-/-- info: true -/
-#guard_msgs in
-#eval testLaws 2 (fun l => l.forks = 2 ∧ l.is_canonical)
+theorem TestLawsBody.mk2 {l r P} (H : P (l ≃ r)) : TestLawsBody l r P :=
+  fun _ _ => H
 
-/-- info: true -/
-#guard_msgs in
-#eval testLaws 4 (fun l => l.forks = 4 ∧ l.is_canonical)
+theorem TestLawsBody.mk3 {l r P}
+    (h1 : decide (l = Lf 0) = false) (h2 : decide (l.comp r = .lt) = false) :
+    TestLawsBody l r P :=
+  fun h => by simp at h1 h2; cases h2 (h h1)
 
-@[simp]
-theorem FreeMagmas.forks_eq_0_iff (m : FreeMagma Nat) :
-  m.forks = 0 ↔ ∃ v, m = .Leaf v := by cases m <;> simp [FreeMagma.forks]
+partial def proveTestLawsBody (l r : FreeMagma Nat) (l' r' : Q(FreeMagma Nat))
+    (P : Q(Law.NatMagmaLaw → Prop))
+    (hP : (l : Law.NatMagmaLaw) → (l : Q(Law.NatMagmaLaw)) → MetaM Q($P $l)) :
+    MetaM Q(TestLawsBody $l' $r' $P) := do
+  if l = .Leaf 0 || l.comp r = .lt then
+    let law := (l ≃ r)
+    if law.symm.canonicalize.comp law = .lt then
+      let e : Q(($l' ≃ $r').symm.canonicalize.comp ($l' ≃ $r') = .lt) := (q(Eq.refl Ordering.lt) :)
+      pure q(TestLawsBody.mk1 $e)
+    else
+      pure q(TestLawsBody.mk2 $(← hP law q($l' ≃ $r')))
+  else
+    let h1 : Q(decide ($l' = Lf 0) = false) := (q(Eq.refl false) :)
+    let h2 : Q(decide (($l').comp $r' = .lt) = false) := (q(Eq.refl false) :)
+    pure q(TestLawsBody.mk3 $h1 $h2)
 
-@[simp]
-theorem FreeMagmas.forks_eq_succ_iff (m : FreeMagma Nat) n :
-    m.forks = n+1 ↔ ∃ l r, m = .Fork l r ∧ l.forks + r.forks = n := by
-  cases m
-  case Leaf => simp [FreeMagma.forks]
-  case Fork l r =>
-    simp only [FreeMagma.forks, Nat.succ_eq_add_one, Nat.add_right_cancel_iff]
-    constructor
-    · intro h; use l, r
-    · rintro ⟨_, _, ⟨rfl, rfl⟩, _⟩; assumption
+def TestLaws (s : Nat) (P : Law.NatMagmaLaw → Prop) :=
+  ∀ l : Law.MagmaLaw Nat, l.forks = s → l.isCanonical → P l
 
-theorem testNat_spec (n : Nat) P :
-    testNat n P = true ↔ ∀ i < n, P i := by
-  induction n
-  next => simp [testNat]
-  next n ih =>
-    simp_all [testNat, Nat.lt_succ_iff_lt_or_eq]; clear ih
-    constructor
-    · rintro ⟨h1,h2⟩ i ⟨h2|h3⟩
-      · exact h2 i (Nat.lt_add_one i)
-      · exact h2 i (Nat.lt_succ_of_lt h3)
-      · subst i; assumption
-    · exact fun h ↦ ⟨h _ (Or.inr rfl), fun i h2 ↦ h _ (Or.inl h2)⟩
+theorem TestLaws.mk {s P}
+    (H : TestAllSplits s fun s1 s2 =>
+    TestFreeMagmas s1 0 fun n l =>
+      TestFreeMagmas s2 n fun _ r =>
+        TestLawsBody l r P)
+    : TestLaws s P := by
+  unfold TestLaws
+  simp [TestAllSplits, TestFreeMagmas] at *
+  rintro ⟨l, r⟩ hs hcan
+  simp [Law.MagmaLaw.isCanonical, Option.isSome_iff_exists, Option.bind_eq_some] at hcan
+  obtain ⟨⟨⟨n'', n', hcan1, hcan2⟩, hcomp⟩, hsymm⟩ := hcan
+  exact H _ _ hs _ _ rfl hcan1 _ _ rfl hcan2 hcomp.resolve_right hsymm
 
-theorem testAllSplits_spec (n : Nat) P :
-    testAllSplits n P = true ↔ ∀ s1 s2, s1 + s2 = n → P s1 s2 := by
-  rw [testAllSplits, testNat_spec]
-  constructor
-  · intro h s1 s2 hs12
-    convert h s1 ?lt <;> omega
-  · intro h i hlt
-    apply h
-    omega
+partial def proveTestLaws (s : Nat) (P : Q(Law.NatMagmaLaw → Prop))
+    (hP : Law.NatMagmaLaw → (m : Q(Law.NatMagmaLaw)) → MetaM Q($P $m)) :
+    MetaM Q(TestLaws $s $P) := do
+  let h ← proveTestAllSplits s fun s1 s2 : Nat =>
+    proveTestFreeMagmas s1 0 q(fun n l => TestFreeMagmas $s2 n fun _ r => TestLawsBody l r $P)
+      fun n l l' => proveTestFreeMagmas s2 n q(fun _ r => TestLawsBody $l' r $P)
+        fun _ r r' => proveTestLawsBody l r l' r' P hP
+  pure q(TestLaws.mk $h)
 
-theorem testFreeMagmas_spec (s n : Nat) P :
-  testFreeMagmas s n P = true ↔ ∀ m n', m.forks = s → m.is_canonical n = some n' → P n' m = true := by
-  induction s, n, P using testFreeMagmas.induct
-  next n P =>
-    simp (config := {contextual := true}) [testFreeMagmas, testNat_spec, FreeMagma.is_canonical]
-    constructor
-    · intro h
-      rintro _ n' i rfl heq
-      specialize h i
-      split at heq
-      next hlt => simp_all; apply h; omega
-      next =>
-        split at heq
-        next => simp_all
-        next  => simp_all
-    · intro h i hi
-      apply h _ _ _ rfl
-      split <;> simp
-      omega
-  next n P s ih2 ih1 =>
-    simp (config := {contextual := true}) [testFreeMagmas, FreeMagma.is_canonical,
-      testAllSplits_spec, Option.bind_eq_some]
-    constructor
-    · rintro h _ n' l r rfl hadd n'' hcan1 hcan2
-      exact ((ih2 _ _ hadd) _ l).mp ((ih1 _ _ hadd).mp (h _ _ hadd) _ _ rfl hcan1) _ _ rfl hcan2
-    · intro h s1 s2 hadd
-      rw [ih1 _ _ hadd]
-      intro l n' hl hcan1
-      rw [ih2 _ _ hadd]
-      intro r n'' hr hcan2
-      apply h _ n'' l r rfl (by simp [*])
-      · exact hcan1
-      · exact hcan2
+def TestLawsUpto (s : Nat) (P : Law.NatMagmaLaw → Prop) :=
+  ∀ l : Law.MagmaLaw Nat, l.forks ≤ s → l.isCanonical → P l
 
-theorem testLaws_spec (s : Nat) P :
-  testLaws s P = true ↔ ∀ l : Law.MagmaLaw Nat, l.forks = s → l.is_canonical → P l = true := by
-  unfold testLaws
-  simp [testAllSplits_spec, testFreeMagmas_spec, Decidable.or_iff_not_imp_left]
-  constructor
-  · rintro h ⟨l, r⟩ hs hcan
-    simp [Law.MagmaLaw.is_canonical] at hcan
-    obtain ⟨⟨hcan, hcomp⟩, hsymm⟩ := hcan
-    cases hcan1 : (FreeMagma.is_canonical 0 l)
-    case none => simp [hcan1] at hcan
-    case some n' =>
-      cases hcan2 : (FreeMagma.is_canonical n' r)
-      case none => simp [hcan1, hcan2] at hcan
-      case some n'' =>
-        apply h l.forks r.forks hs l _ rfl hcan1 _ _ rfl hcan2
-        · intro hnLf0; simp_all
-        · assumption
-  · rintro h s1 s2 hs12 l n' hl hcan1 r n'' hr hcan2 hcomp hsymm
-    apply h
-    · simp [Law.MagmaLaw.forks, hs12, hl, hr]
-    · simp [Law.MagmaLaw.is_canonical, hcan1, hcan2, hsymm]
-      tauto
+theorem TestLawsUpto.mk {s P}
+    (H : TestNat (s+1) fun s' => TestLaws s' P)
+    : TestLawsUpto s P := by
+  simp [TestLawsUpto, TestLaws, TestNat, Nat.lt_succ_iff] at *
+  intro i his hcanon
+  exact H _ his _ rfl hcanon
 
-theorem testLawsUpto_spec (s : Nat) P :
-    testLawsUpto s P = true ↔ ∀ l : Law.MagmaLaw Nat, l.forks ≤ s → l.is_canonical → P l = true := by
-  simp [testLawsUpto, testLaws_spec, testNat_spec, Nat.lt_succ_iff]
-  constructor
-  · intro h i his hcanon
-    apply h _ his _ rfl hcanon
-  · rintro h i his l rfl hcanon
-    apply h _ his hcanon
-
-/--
-Here we do the actual computation. For now using `native_decide`, more serious
-engineering is necessary if we insist on using `by decide` here.
--/
-theorem testLawsUpto4_computation :
-  testLawsUpto 4 (fun l => laws[findMagmaLaw l] = l) = true := by native_decide
-
-theorem laws_complete' :
-    ∀ l : Law.MagmaLaw Nat, l.forks ≤ 4 → l.is_canonical → laws[findMagmaLaw l] = l := by
-  simpa [decide_eq_true_eq]
-    using (testLawsUpto_spec 4 (fun l => laws[findMagmaLaw l] = l)).mp testLawsUpto4_computation
+partial def proveTestLawsUpto (s : Nat) (P : Q(Law.NatMagmaLaw → Prop))
+    (hP : Law.NatMagmaLaw → (m : Q(Law.NatMagmaLaw)) → MetaM Q($P $m)) :
+    MetaM Q(TestLawsUpto $s $P) := do
+  let h ← proveTestNat (s+1) fun s' : Nat => proveTestLaws s' P hP
+  pure q(TestLawsUpto.mk $h)
 
 /--
 This theorem demonstrates that `laws`, the list of laws considered in this project, indeed
 contains all (canonically represented) magma laws up to 4 operations.
 -/
 theorem laws_complete :
-    ∀ l : Law.MagmaLaw Nat, l.forks ≤ 4 → l.is_canonical → ∃ (i : Nat), laws[i] = l :=
-  fun l hl hcan => ⟨findMagmaLaw l, laws_complete' l hl hcan⟩
+    ∀ l : Law.MagmaLaw Nat, l.forks ≤ 4 → l.isCanonical → ∃ (i : Nat), laws[i] = l :=
+  by_elab proveTestLawsUpto 4 q(fun l => ∃ i : Nat, laws[i] = l) fun l l' => do
+    let i : Nat := findMagmaLaw l
+    let h : Q(laws[$i] = $l') := (q(Eq.refl $l') :)
+    pure q(⟨$i, $h⟩)

--- a/equational_theories/RArray.lean
+++ b/equational_theories/RArray.lean
@@ -1,4 +1,4 @@
-import Lean
+import Lean.ToExpr
 
 /-!
 A data structure for modelling `Fin n → α` (or `Array α`) optimized for a fast kernel-reduction get
@@ -16,24 +16,24 @@ variable {α : Type}
 
 /-- The crucial operation, written with very little abstractional overhead -/
 noncomputable def RArray.get (a : RArray α) (n : Nat) : α :=
-  RArray.rec (fun x => x) (fun p _ _ l r => (Nat.ble p n).rec l r) a
+  RArray.rec (fun x _ => x) (fun p _ _ l r n => (p.ble n).rec (l n) (r (n.sub p))) a n
 
 theorem RArray.get_eq_def (a : RArray α) (n : Nat) :
   a.get n = match a with
     | .leaf x => x
-    | .branch p l r => (Nat.ble p n).rec (l.get n) (r.get n) := by
+    | .branch p l r => (Nat.ble p n).rec (l.get n) (r.get (n.sub p)) := by
   conv => lhs; unfold RArray.get
   split <;> rfl
 
 def RArray.getImpl (a : RArray α) (n : Nat) : α :=
   match a with
   | .leaf x => x
-  | .branch p l r => if n < p then l.getImpl n else r.getImpl n
+  | .branch p l r => if n < p then l.getImpl n else r.getImpl (n - p)
 
 @[csimp]
 theorem RArray.get_eq_getImpl : @RArray.get = @RArray.getImpl := by
   ext α a n
-  induction a with
+  induction a generalizing n with
   | leaf _ => rfl
   | branch p l r ihl ihr =>
     rw [RArray.getImpl, RArray.get_eq_def]
@@ -44,7 +44,7 @@ theorem RArray.get_eq_getImpl : @RArray.get = @RArray.getImpl := by
       rw [if_pos]
       omega
     · simp at hnp
-      rw [if_neg]
+      rw [if_neg]; rfl
       omega
 
 instance : GetElem (RArray α) Nat α (fun _ _ => True) where
@@ -54,6 +54,29 @@ def RArray.size : RArray α → Nat
   | leaf _ => 1
   | branch _ l r => l.size + r.size
 
+def RArray.checkSize : RArray α → Option Nat
+  | leaf _ => some 1
+  | branch n l r =>
+    l.checkSize.bind fun a =>
+    r.checkSize.bind fun b =>
+    bif n.beq a then some (a + b) else none
+
+def RArray.WF : RArray α → Prop
+  | leaf _ => True
+  | branch n l r => n = l.size ∧ l.WF ∧ r.WF
+
+theorem RArray.checkSize_iff {arr : RArray α} {n} :
+    arr.checkSize = some n ↔ arr.WF ∧ arr.size = n := by
+  induction arr generalizing n <;>
+    simp only [checkSize, Option.some.injEq, WF, size, true_and, Option.bind_eq_some, and_assoc,
+      exists_and_left, exists_eq_left', and_left_comm, *]
+  repeat apply and_congr_right'
+  rename_i i l _ _ _
+  cases e : i.beq l.size <;> simp [Bool.eq_false_iff] at e <;> simp [e]
+
+instance (arr : RArray α) : Decidable arr.WF :=
+  decidable_of_bool arr.checkSize.isSome <| by simp [Option.isSome_iff_exists, RArray.checkSize_iff]
+
 def RArray.ofFn {n : Nat} (f : Fin n → α) (h : 0 < n) : RArray α :=
   go 0 n h (Nat.le_refl _)
 where
@@ -62,7 +85,7 @@ where
       .leaf (f ⟨lb, Nat.lt_of_lt_of_le h1 h2⟩)
     else
       let mid := (lb + ub)/2
-      .branch mid (go lb mid (by omega) (by omega)) (go mid ub (by omega) h2)
+      .branch (mid - lb) (go lb mid (by omega) (by omega)) (go mid ub (by omega) h2)
 
 def ofArray (xs : Array α) (h : 0 < xs.size) : RArray α :=
   .ofFn (fun i => xs.get i) h
@@ -71,7 +94,8 @@ theorem RArray.ofFn_correct {n : Nat} (f : Fin n → α) (h : 0 < n) (i : Fin n)
     RArray.get (.ofFn f h) i = f i :=
   go 0 n h (Nat.le_refl _) (Nat.zero_le _) i.2
 where
-  go lb ub h1 h2 (h3 : lb ≤ i.val) (h3 : i.val < ub) : RArray.get (.ofFn.go f lb ub h1 h2) i = f i := by
+  go lb ub h1 h2 (h3 : lb ≤ i.val) (h3 : i.val < ub) :
+      RArray.get (.ofFn.go f lb ub h1 h2) (i - lb) = f i := by
     induction lb, ub, h1, h2 using RArray.ofFn.go.induct (f := f) (n := n)
     case case1 =>
       simp [ofFn.go, RArray.get_eq_getImpl, RArray.getImpl]
@@ -82,8 +106,12 @@ where
       simp [RArray.get_eq_getImpl, RArray.getImpl] at *
       split
       · rw [ih1] <;> omega
-      · rw [ih2] <;> omega
+      · rw [Nat.sub_sub, Nat.add_sub_cancel' (by omega)]
+        rw [ih2] <;> omega
 
+def RArray.toArray : RArray α → (out : Array α := #[]) → Array α
+  | .leaf x, out => out.push x
+  | .branch _ a b, out => b.toArray (a.toArray out)
 
 section Meta
 open Lean


### PR DESCRIPTION
Proof by example that lean is much better at verifying simple proof terms than doing recursive computations in the kernel using `decide`. `#time` says it takes 7 seconds, but because it is checked twice as written (once in the kernel and once in the elaborator) half of this time could be eliminated with some additional work.