### PR TITLE
bug fix: extract_implications --full-entries

### DIFF
--- a/scripts/extract_implications.lean
+++ b/scripts/extract_implications.lean
@@ -166,11 +166,11 @@ def generateOutput (inp : Cli.Parsed) : IO UInt32 := do
 
 def generateRaw (inp : Cli.Parsed) : IO UInt32 := do
   withExtractedResults inp fun rs _dualityRelation => do
+    let rs := matchFinite rs (inp.hasFlag "finite-only")
     if inp.hasFlag "full-entries" then
       IO.println (toJson rs).compress
       return
     let rs := if inp.hasFlag "proven" then rs.filter (·.proven) else rs
-    let rs := matchFinite rs (inp.hasFlag "finite-only")
     let mut implications : Array Implication := #[]
     let mut facts : Array Facts := #[]
     let mut unconditionals : Array String := #[]


### PR DESCRIPTION
Right now, `extract_implications raw --full-entries` prints entries, intermingling results for the finite and general graphs. This can lead to some downstream data issues, such as the two different proofs [here](https://teorth.github.io/equational_theories/implications/show_proof.html?3308,3456).

In this change, I change it to only print results for either the finite, or general graph, and a follow-up change will plumb support for the finite graph to the equation explorer.