### PR TITLE
Equation Explorer + Graphiti: Finite Graph support

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -160,6 +160,9 @@ jobs:
           ~/.elan/bin/lake exe extract_implications outcomes > /tmp/out.json
           ~/.elan/bin/lake exe extract_implications raw --full-entries > /tmp/out2.json
           python scripts/generate_equation_explorer_graph.py /tmp/out.json /tmp/out2.json > home_page/implications/graph.json
+          ~/.elan/bin/lake exe extract_implications outcomes --finite-only > /tmp/out.finite.json
+          ~/.elan/bin/lake exe extract_implications raw --full-entries --finite-only > /tmp/out2.finite.json
+          python scripts/generate_equation_explorer_graph.py /tmp/out.finite.json /tmp/out2.finite.json > home_page/implications/finite_graph.json
 
       - name: Generate the Finite Magma Explorer website
         run: |
@@ -179,9 +182,11 @@ jobs:
 
       - name: Generate home_page/graphiti/graph.json
         run: |
-          ~/.elan/bin/lake exe extract_implications --json --only-implications --closure equational_theories > /tmp/implications.json
+          ~/.elan/bin/lake exe extract_implications --json --only-implications --closure > /tmp/implications.json
           ~/.elan/bin/lake exe extract_implications unknowns > /tmp/unknowns.json
-          ruby scripts/generate_graphiti_data.rb /tmp/implications.json /tmp/unknowns.json data/duals.json > home_page/graphiti/graph.json
+          ~/.elan/bin/lake exe extract_implications --json --only-implications --closure --finite-only > /tmp/implications.fin.json
+          ~/.elan/bin/lake exe extract_implications unknowns --finite-only > /tmp/unknowns.fin.json
+          ruby scripts/generate_graphiti_data.rb data/duals.json /tmp/implications.json /tmp/unknowns.json /tmp/implications.fin.json /tmp/unknowns.fin.json > home_page/graphiti/graph.json
 
       - name: Build website using Jekyll
         if: github.event_name == 'push' && env.HOME_PAGE_EXISTS == 'true'

--- a/home_page/graphiti/index.html
+++ b/home_page/graphiti/index.html
@@ -9,6 +9,7 @@
     <style>
       body {
         font-family: Arial, sans-serif;
+        padding: 20px;
         margin: 0;
         margin-top: 25px; /* Adjust this value to match the height of your top bar */
       }
@@ -91,6 +92,23 @@
       .top-bar a:hover {
         text-decoration: underline;
       }
+
+      #finiteGreenBand {
+        display: none;
+        position: fixed;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 15px;
+        background-color: green;
+        color: white;
+        font-size: 15px;
+        font-weight: bold;
+        writing-mode: vertical-rl;
+        text-align: center;
+        padding-top: 10px;
+        transform: rotate(180deg);
+      }
     </style>
 
     <script src="https://d3js.org/d3.v7.js"></script>
@@ -99,6 +117,8 @@
   </head>
 
   <body>
+    <div id="finiteGreenBand">Finite Graph</div>
+
     <div class="container" id="container" style="display: none">
       <img
         src="logo.png"
@@ -164,6 +184,15 @@
           >Highlight equations in blue (numeric, comma-separated):</label
         >
         <input type="text" id="highlight_blue" name="highlight_blue" /><br />
+
+        <div class="checkbox-container">
+          <input
+            type="checkbox"
+            id="show_finite_graph"
+            name="show_finite_graph"
+          />
+          <label for="show_finite_graph">Show finite graph</label>
+        </div>
 
         <div class="checkbox-container">
           <input
@@ -288,8 +317,9 @@
 
     <script>
       const EQUATION_EXPLORER_URL =
-        "https://teorth.github.io/equational_theories/implications/?";
+        "https://teorth.github.io/equational_theories/implications/";
       let dotFile = "";
+      let graph_json;
 
       function hideVisibility(elementId) {
         const element = document.getElementById(elementId);
@@ -428,6 +458,8 @@
 
         // Use history.replaceState to modify the URL without reloading the page
         history.replaceState(null, "", url);
+
+        document.getElementById("finiteGreenBand").style.display = "none";
       }
 
       function downloadSVG(event) {
@@ -543,8 +575,6 @@
         d3.selectAll(".node").selectAll("a").attr("target", "_blank");
       }
 
-      var graph_json = undefined;
-
       function vertices(adj_list) {
         let vertices = new Set();
 
@@ -630,11 +660,21 @@
           new URLSearchParams(window.location.search).entries(),
         );
 
+        if (params.show_finite_graph) {
+          document.getElementById("finiteGreenBand").style.display = "block";
+        } else {
+          document.getElementById("finiteGreenBand").style.display = "none";
+        }
+
+        let graph_idx = params.show_finite_graph
+          ? "finite_graph"
+          : "general_graph";
+
         let vertices_to_delete = new Set();
 
-        let node_to_scc_map = { ...graph_json.node_to_scc_map };
-        let scc_to_node_map = { ...graph_json.scc_to_node_map };
-        let graph = graph_json.condensed_graph;
+        let node_to_scc_map = { ...graph_json[graph_idx].node_to_scc_map };
+        let scc_to_node_map = { ...graph_json[graph_idx].scc_to_node_map };
+        let graph = graph_json[graph_idx].condensed_graph;
 
         if (params.show_sporadic_equations != "on") {
           for (const key of Object.keys(node_to_scc_map)) {
@@ -904,7 +944,9 @@ digraph G {
             dotFile += `,style=filled,fillcolor="#ADD8E6"`;
           }
 
-          dotFile += `,href="${EQUATION_EXPLORER_URL}${scc[0]}"]\n`;
+          let finite = params.show_finite_graph ? "&finite" : "";
+
+          dotFile += `,href="${EQUATION_EXPLORER_URL}?${scc[0]}${finite}"]\n`;
         }
         console.log(`Vertices: ${sccs.length}`);
 
@@ -920,11 +962,11 @@ digraph G {
         if (params.show_unknowns_conjectures == "on") {
           let unknown_edges = 0;
           for (const scc_name of Object.keys(scc_to_node_map)) {
-            if (!graph_json.unknowns[scc_name]) {
+            if (!graph_json[graph_idx].unknowns[scc_name]) {
               continue;
             }
 
-            graph_json.unknowns[scc_name]
+            graph_json[graph_idx].unknowns[scc_name]
               .filter((x) => x in scc_to_node_map)
               .forEach((x) => {
                 dotFile += `  ${scc_name} -> ${x} [style="dotted",constraint=false]\n`;

--- a/home_page/implications/.gitignore
+++ b/home_page/implications/.gitignore
@@ -1,2 +1,3 @@
 implications.js
+finite_graph.json
 graph.json

--- a/home_page/implications/index.html
+++ b/home_page/implications/index.html
@@ -97,10 +97,29 @@
     background-color: #f0f0f0;
 }
 
+      #finiteGreenBand {
+        display: none;
+        position: fixed;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        width: 15px;
+        background-color: green;
+        color: white;
+        font-size: 15px;
+        font-weight: bold;
+        writing-mode: vertical-rl;
+        text-align: center;
+        padding-top: 10px;
+        transform: rotate(180deg);
+      }
+
     </style>
 
   </head>
   <body>
+    <div id="finiteGreenBand">Finite Graph</div>
+
     <div id="listPage" class="page active">
       <h1>Equation Explorer</h1>
 
@@ -148,6 +167,9 @@
           <input type="checkbox" checked="checked" id="treatConjectedAsUnknownList"> Treat conjectures as unknown
         </label>
         <label>
+          <input type="checkbox" id="showFiniteGraphList"> Display the finite graph
+        </label>
+        <label>
           <input type="checkbox" id="hideFullySolved"> Hide fully-solved equations
         </label>
       </div>
@@ -174,10 +196,13 @@
           <input type="checkbox" checked="checked" id="showEquivalences2"> Hide equivalent equations
         </label>
         <label>
-          <input type="checkbox" id="showOnlyExplicitProofs"> Show only explicit proofs
+          <input type="checkbox" checked="checked" id="treatConjectedAsUnknownDetail"> Treat conjectures as unknown
         </label>
         <label>
-          <input type="checkbox" checked="checked" id="treatConjectedAsUnknownDetail"> Treat conjectures as unknown
+          <input type="checkbox" id="showFiniteGraphDetail"> Display the finite graph
+        </label>
+        <label>
+          <input type="checkbox" id="showOnlyExplicitProofs"> Show only explicit proofs
         </label>
 
       </div>

--- a/home_page/implications/show_proof.html
+++ b/home_page/implications/show_proof.html
@@ -8,17 +8,47 @@
   <style>
     body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }
     a { text-decoration: inherit; color: inherit; }
-    div { margin: 0.5em; }
     .arrow { font-size: x-large; margin-right: 0.5em; }
+    .implication, .nonimplication, .equation { margin: 0.5em; }
     .implication, .nonimplication { margin-left: 2em; display: flex; align-items: center; }
+    #finiteGreenBand {
+      display: none;
+      position: fixed;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 15px;
+      background-color: green;
+      color: white;
+      font-size: 15px;
+      font-weight: bold;
+      writing-mode: vertical-rl;
+      text-align: center;
+      padding-top: 10px;
+      transform: rotate(180deg);
+    }
   </style>
 </head>
 <body>
+<div id="finiteGreenBand">Finite Graph</div>
 <script>
 "use strict";
 
+const params = Object.fromEntries(
+    new URLSearchParams(window.location.search).entries(),
+);
+
+const eqStr = params.pair || window.location.search.substring(1);
+const [eq1, eq2] = eqStr.split(',');
+
+const isFiniteGraph = params.finite !== undefined;
+
+if (isFiniteGraph) {
+    document.getElementById("finiteGreenBand").style.display = "block";
+}
+
 (async () => {
-  const response = await fetch('graph.json');
+  const response = await fetch(isFiniteGraph ? 'finite_graph.json' : 'graph.json');
   if (!response.ok) {
     console.error(`HTTP error! Status: ${response.status}`);
     return;
@@ -27,7 +57,6 @@
   const full_entries = jsondata["full_entries"];
 
   let t1 = Date.now();
-  const [eq1, eq2] = window.location.search.substring(1).split(",");
 
   const dualsIndex = {};
   for (let pair of duals) {
@@ -160,7 +189,8 @@
 
   function render_equation(node) {
     const eq = parseInt(node.toString().replace("_neg", ""));
-    const url = `./?${eq}`;
+    let url = `./?${eq}`;
+    if (isFiniteGraph) url += "&finite";
     document.body.innerHTML += `
       <div class="equation">
         <a href="${url}" target="_blank">${equations[eq - 1]}</a>

--- a/scripts/generate_graphiti_data.rb
+++ b/scripts/generate_graphiti_data.rb
@@ -1,17 +1,15 @@
-# lake exe extract_implications --json --only-implications --closure equational_theories > /tmp/implications.json
-# lake exe extract_implications unknowns > /tmp/unknowns.json
-# ruby scripts/generate_graphiti_data.rb /tmp/implications.json /tmp/unknowns.json data/duals.json > home_page/graphiti/graph.json
+# See .github/workflows/blueprint.yml for proper invocation to generate graphiti data. Then run:
 # python -m http.server 8000 --directory home_page/graphiti
 
 require 'json'
 require File.join(__dir__, 'graph')
 
-if ARGV.length != 3
-  $stderr.puts "Usage: scripts/generate_graphiti_data.rb <implications json> <unknowns json> <duals json>"
+if ARGV.length != 5
+  $stderr.puts "Usage: scripts/generate_graphiti_data.rb <duals json> <implications json> <unknowns json> <finite implications json> <finite unknowns json>"
   exit 1
 end
 
-duals = JSON.parse(File.read(ARGV[2]))
+duals = JSON.parse(File.read(ARGV[0]))
 
 equations = {}
 ["1_999", "1000_1999", "2000_2999", "3000_3999", "4000_4694"].each { |i|
@@ -32,24 +30,6 @@ File.read(File.join(__dir__, '../equational_theories/Equations/Basic.lean')).spl
   end
 }
 
-implications_graph = Graph.from_json_array(JSON.parse(File.read(ARGV[0]))["implications"])
-condensed_graph, node_to_scc_map, scc_to_node_map = implications_graph.condensation
-
-unknowns = Graph.new
-Graph.from_json_array(JSON.parse(File.read(ARGV[1]))).adj_list.each { |v1, list|
-  list.each { |v2|
-    v1_scc = node_to_scc_map[v1]
-    v2_scc = node_to_scc_map[v2]
-
-    if !v1_scc || !v2_scc
-      $stderr.puts "Unknown LHS/RHS mapping to SCC"
-      exit 1
-    end
-
-    unknowns.add_edge(v1_scc, v2_scc)
-  }
-}
-
 def graph2map(g)
   out = {}
   g.adj_list.each { |k, v| out[k] = v.to_a.sort }
@@ -57,15 +37,40 @@ def graph2map(g)
   out
 end
 
-scc_to_node_map.keys.each { |k| scc_to_node_map[k].sort! }
+def gen_graph(imp_file, unknowns_file)
+  implications_graph = Graph.from_json_array(JSON.parse(File.read(imp_file))["implications"])
+  condensed_graph, node_to_scc_map, scc_to_node_map = implications_graph.condensation
+
+  unknowns = Graph.new
+  Graph.from_json_array(JSON.parse(File.read(unknowns_file))).adj_list.each { |v1, list|
+    list.each { |v2|
+      v1_scc = node_to_scc_map[v1]
+      v2_scc = node_to_scc_map[v2]
+
+      if !v1_scc || !v2_scc
+        $stderr.puts "Unknown LHS/RHS mapping to SCC"
+        exit 1
+      end
+
+      unknowns.add_edge(v1_scc, v2_scc)
+    }
+  }
+
+  scc_to_node_map.keys.each { |k| scc_to_node_map[k].sort! }
+
+  {
+    "condensed_graph" => graph2map(condensed_graph),
+    "scc_to_node_map" => scc_to_node_map,
+    "node_to_scc_map" => node_to_scc_map,
+    "unknowns" => graph2map(unknowns),
+  }
+end
 
 puts JSON.generate({
   "timestamp" => Time.now.utc.to_i,
   "commit_hash" => `git rev-parse HEAD`.chomp,
-  "condensed_graph" => graph2map(condensed_graph),
-  "scc_to_node_map" => scc_to_node_map,
-  "node_to_scc_map" => node_to_scc_map,
   "equations" => equations,
-  "unknowns" => graph2map(unknowns),
-  "duals" => duals
+  "duals" => duals,
+  "general_graph" => gen_graph(ARGV[1], ARGV[2]),
+  "finite_graph" => gen_graph(ARGV[3], ARGV[4]),
 })


### PR DESCRIPTION
In this change I generate data for the finite graph for both equation explorer and graphiti, and plumb support for displaying it there. All previous links and functionality should work identically.

In order to reduce confusion, I add a green stripe to the left-side of the page when viewing the finite graph.