### PR TITLE
Finite implication search: refactor/add more features

### DIFF
--- a/equational_theories/Generated/FiniteImplicationSearch.lean
+++ b/equational_theories/Generated/FiniteImplicationSearch.lean
@@ -1,1 +1,1 @@
-import equational_theories.Generated.FiniteImplicationSearch.theorems.Proofs1
+import equational_theories.Generated.FiniteImplicationSearch.theorems.Inverses1

--- a/equational_theories/Generated/FiniteImplicationSearch/README.md
+++ b/equational_theories/Generated/FiniteImplicationSearch/README.md
@@ -1,29 +1,42 @@
 # Finite Implication Search
 
-This tool searches for finite implications by using Vampire and making use of the fact left and right inverses are interchangeable in finite domains.
+This tool searches for finite implications by using Vampire and adding axioms for various facts that hold true in finite domains.
 
-## Step 1
+Note that if `generate_tptp.rb` is not passed any options, it can also be used to generate Lean proofs for ordinary implications in the general implication graph.
 
-First, we generate a directory full of TPTP files to pass to Vampire. These files include commented out JSON blobs that are used for proof generation later.
+## Finite implication search methods
+
+- Left and right inverses are interchangeable in finite domains. (Note that currently the inverses option only searches for inverses of the source of the implication, and not the destination. One has to manually check implications to the inverses of any destinations.)
+- Injectivity bi-implies surjectivity (Note: you can add axioms to search with, but `process.py` can't generate the Lean proofs for the resulting hits.)
+- A heuristic method to look for [proofs by periodicity](https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/Austin.20pairs/near/483445305).
+
+See the options of `generate_tptp.rb`.
+
+## Basic usage
+
+### Step 1
+
+First, we generate a directory full of TPTP files to pass to Vampire. These files include commented out JSON blobs that are used for proof generation later. The input is a CSV of implications to attempt.
 
 ```sh
-lake exe export_equations > equations.json
 lake exe extract_implications unknowns --proven --finite-only --duality | ruby -rjson -e 'JSON.parse($stdin.read).each { |s| puts s["lhs"][8,10] + "," + s["rhs"][8,10] }' | sort -u > unknowns.csv
-cat unknowns.csv | ruby equational_theories/Generated/FiniteImplicationSearch/src/generate_tptp.rb equations.json finite_implications
+cat unknowns.csv | ruby equational_theories/Generated/FiniteImplicationSearch/src/generate_tptp.rb --inverses finite_implications
 ```
 
 This creates a directory `finite_implications/`.
 
-## Step 2
+### Step 2
 
 Run Vampire, this generates `.p.out` files for every TPTP `.p` file.
 
 ```sh
-ls finite_implications/*.p | ruby -ne 'puts "vampire --output_axiom_names on --proof_extra full -t 0.4s #{$_.chomp} > #{$_.chomp}.out"' > /tmp/run.sh
+find finite_implications -name \*.p | ruby -ne 'puts "vampire --output_axiom_names on --proof_extra full -t 0.5s #{$_.chomp} > #{$_.chomp}.out"' > /tmp/run.sh
 bash /tmp/run.sh
 ```
 
-## Step 3
+Note that depending on the options used and the underlying implications, you may want to increase the timeout from 0.5s.
+
+### Step 3
 
 Post-process Vampire output:
 

--- a/equational_theories/Generated/FiniteImplicationSearch/src/generate_tptp.rb
+++ b/equational_theories/Generated/FiniteImplicationSearch/src/generate_tptp.rb
@@ -1,6 +1,30 @@
+require 'optparse'
+require 'open3'
 require 'json'
+require 'set'
 
-VARS = "XYZWUV"
+FIND_EQUATION_ID = File.join(__dir__, '..', '..', '..', '..', 'scripts', 'find_equation_id.py')
+
+# A fairly minimal set that I computed that were required to solve different finite implications
+# up to order 4.
+SIMPLE_BIJECTIONS = [
+  ["eq3_surj_inj", "![X] : ?[T] : ( X = mul(T, T) ) => ![T1,T2] : ( (mul(T1, T1) = mul(T2, T2) ) => T1 = T2 )"],
+  ["eq3_inj_surj", "![T1,T2] : ( (mul(T1, T1) = mul(T2, T2) ) => T1 = T2 ) => ![X] : ?[T] : ( X = mul(T, T) )"],
+  ["eq4_surj_inj", "![X,Y] : ?[T] : ( X = mul(T, Y) ) => ![Y,T1,T2] : ( (mul(T1, Y) = mul(T2, Y) ) => T1 = T2 )"],
+  ["eq4_inj_surj", "![Y,T1,T2] : ( (mul(T1, Y) = mul(T2, Y) ) => T1 = T2 ) => ![X,Y] : ?[T] : ( X = mul(T, Y) )"],
+  ["eq5_surj_inj", "![X,Y] : ?[T] : ( X = mul(Y, T) ) => ![Y,T1,T2] : ( (mul(Y, T1) = mul(Y, T2) ) => T1 = T2 )"],
+  ["eq5_inj_surj", "![Y,T1,T2] : ( (mul(Y, T1) = mul(Y, T2) ) => T1 = T2 ) => ![X,Y] : ?[T] : ( X = mul(Y, T) )"],
+  ["eq8_surj_inj", "![X] : ?[T] : ( X = mul(T, mul(T, T)) ) => ![T1,T2] : ( (mul(T1, mul(T1, T1)) = mul(T2, mul(T2, T2)) ) => T1 = T2 )"],
+  ["eq8_inj_surj", "![T1,T2] : ( (mul(T1, mul(T1, T1)) = mul(T2, mul(T2, T2)) ) => T1 = T2 ) => ![X] : ?[T] : ( X = mul(T, mul(T, T)) )"],
+  ["eq11_surj_inj", "![X,Y] : ?[T] : ( X = mul(T, mul(Y, Y)) ) => ![Y,T1,T2] : ( (mul(T1, mul(Y, Y)) = mul(T2, mul(Y, Y)) ) => T1 = T2 )"],
+  ["eq11_inj_surj", "![Y,T1,T2] : ( (mul(T1, mul(Y, Y)) = mul(T2, mul(Y, Y)) ) => T1 = T2 ) => ![X,Y] : ?[T] : ( X = mul(T, mul(Y, Y)) )"],
+  ["eq23_surj_inj", "![X] : ?[T] : ( X = mul(mul(T, T), T) ) => ![T1,T2] : ( (mul(mul(T1, T1), T1) = mul(mul(T2, T2), T2) ) => T1 = T2 )"],
+  ["eq23_inj_surj", "![T1,T2] : ( (mul(mul(T1, T1), T1) = mul(mul(T2, T2), T2) ) => T1 = T2 ) => ![X] : ?[T] : ( X = mul(mul(T, T), T) )"],
+  ["eq31_surj_inj", "![X,Y] : ?[T] : ( X = mul(mul(Y, Y), T) ) => ![Y,T1,T2] : ( (mul(mul(Y, Y), T1) = mul(mul(Y, Y), T2) ) => T1 = T2 )"],
+  ["eq31_inj_surj", "![Y,T1,T2] : ( (mul(mul(Y, Y), T1) = mul(mul(Y, Y), T2) ) => T1 = T2 ) => ![X,Y] : ?[T] : ( X = mul(mul(Y, Y), T) )"],
+]
+
+VARS = "XYZWUVRSTABCDEFGHIJKLMNOPQ"
 
 def expr_repr(e)
   return VARS[e] if e.class == Integer
@@ -9,16 +33,8 @@ def expr_repr(e)
   return "(#{expr_repr(e[0])} ◇ #{expr_repr(e[1])})"
 end
 
-def simplify_expr(t)
-  if t["leaf"]
-    return t["leaf"]
-  end
-
-  return [ simplify_expr(t["left"]), simplify_expr(t["right"]) ]
-end
-
-def simplify_eq(t)
-  [ simplify_expr(t["lhs"]), simplify_expr(t["rhs"]) ]
+def eq_repr(eq)
+  "#{expr_repr(eq[0])} = #{expr_repr(eq[1])}"
 end
 
 # Map vars to bits
@@ -54,14 +70,19 @@ def subtree_search(tree, subtree)
   matches
 end
 
-def leanify_inverse(src_lhs, operation, inv_operation, inverted)
+def leanify_eq(eq)
+  "∀ " + eq.flatten.uniq.map { |x| VARS[x] }.join(" ") + " : G, " + eq_repr(eq)
+end
+
+def leanify_inverse(operation, inv_operation, inverted)
+  src_lhs = inverted[0]
   str_operation = expr_repr operation
   str_inv_operation = expr_repr inv_operation
 
   proof = []
   proof << "  have REPLACE (" + inverted.flatten.uniq.map { |x| VARS[x] }.join(" ") + " : G) : " + expr_repr(inverted[1]) + " = " + expr_repr(inverted[0]) + " := by"
   if [src_lhs].flatten.length > 1
-    proof << "    let S := {x | ∃ a b : G, a ◇ b = x}"
+    proof << "    let S := {a | ∃ " + [inverted[0]].flatten.uniq.map { |x| VARS[x] }.join(" ") + " : G, " + expr_repr(inverted[0]) + " = a}"
   else
     proof << "    let S : Set G := Set.univ"
   end
@@ -78,7 +99,7 @@ def leanify_inverse(src_lhs, operation, inv_operation, inverted)
 END
   if [src_lhs].flatten.length > 1
     proof << "      simp only [Set.mem_setOf_eq, S] at ha"
-    proof << "      obtain ⟨a, b, rfl⟩ := ha"
+    proof << "      obtain ⟨" + [inverted[0]].flatten.uniq.map { |x| "abcdefghijkl"[x] }.join(", ") + ", rfl⟩ := ha"
   end
   proof.push <<-END
       simp [S]
@@ -107,89 +128,446 @@ def tptp(eq, var_names=VARS)
   "![" + vars.map { |v| var_names[v] }.join(",") + "] : " + eq2tptp(eq[0], eq[1], var_names)
 end
 
-if ARGV.length != 2
-  $stderr.puts "Arguments: <equations.json> <output directory>"
-  exit 1
+def gen_sequences(num_vars, min_var=-1, prev=[], &block)
+  return if num_vars == 0
+  0.upto(min_var+1) { |l|
+    cur = prev + [l]
+    if num_vars == 1
+      yield(cur)
+    else
+      gen_sequences(num_vars - 1, [min_var,l].max, cur, &block)
+    end
+  }
 end
 
-$equations = {}
-JSON.parse(File.read(ARGV[0])).each { |a|
-  eq_num = a['equation'][8,16].to_i
-  $equations[eq_num] = a
-}
+def gen_shapes(array)
+  if array.length == 1
+    yield array[0]
+    return
+  elsif array.length == 2
+    yield array
+    return
+  end
+
+  0.upto(array.length - 1) { |i|
+    gen_shapes(array[0, i]) { |left|
+      gen_shapes(array[i, array.length]) { |right|
+        yield([left, right])
+      }
+    }
+  }
+end
+
+def gen_exprs_upto(num_vars, min_var=-1, &block)
+  1.upto(num_vars) { |i|
+    gen_sequences(i, min_var) { |seq|
+      gen_shapes(seq, &block)
+    }
+  }
+end
+
+def gen_equations(lhs_size, rhs_size, &block)
+  counter = 0
+  seen = {}
+
+  gen_exprs_upto(lhs_size) { |lhs|
+    gen_exprs_upto(rhs_size, 0) { |rhs|
+      next if ![rhs].flatten.include?(0) # We want the LHS to be included
+      next if [rhs].flatten.length == 1
+
+      next if seen[[lhs, rhs]]
+      seen[[lhs,rhs]]=true
+
+      lhs_max_var = [lhs].flatten.max
+      rhs_max_var = [rhs].flatten.max
+
+      # Order matters here!
+      rhs_max_var.downto(1) { |i|
+        rhs = subtree_replace(rhs, i, lhs_max_var+i)
+      }
+      rhs = subtree_replace(rhs, 0, lhs)
+
+      yield(counter, lhs, rhs)
+      counter += 1
+    }
+  }
+end
+
+def gen_bij_tptp(lhs, rhs)
+  return if lhs == rhs
+  return if [lhs].flatten.length == 1 && [rhs].flatten.length == 1
+
+  # TODO: Support LHS.length > 1
+  raise "LHS length must be 1" if [lhs].flatten.length != 1
+
+  surj_lhs = lhs
+  surj_rhs = rhs
+
+  inj1, inj2 = surj_rhs, surj_rhs
+  inj_final_eq1, inj_final_eq2 = lhs, lhs
+
+  [lhs].flatten.uniq.each { |chosen_lhs_var|
+    surj_rhs = subtree_replace(surj_rhs, chosen_lhs_var, VARS[chosen_lhs_var] + "T")
+    inj1 = subtree_replace(inj1, chosen_lhs_var, VARS[chosen_lhs_var] + "T1")
+    inj2 = subtree_replace(inj2, chosen_lhs_var, VARS[chosen_lhs_var] + "T2")
+    inj_final_eq1 = subtree_replace(inj_final_eq1, chosen_lhs_var, VARS[chosen_lhs_var] + "T1")
+    inj_final_eq2 = subtree_replace(inj_final_eq2, chosen_lhs_var, VARS[chosen_lhs_var] + "T2")
+  }
+
+  vars_str1 = [surj_lhs, surj_rhs].flatten.uniq.keep_if { |i| i.class != String }.sort.map { |i| VARS[i] }.join(",")
+  vars_str11 = [surj_lhs, surj_rhs].flatten.uniq.keep_if { |i| i.class == String }.sort.join(",")
+  vars_str2 = [inj1, inj2].flatten.uniq.map { |i|
+    if i.class == String
+      i
+    else
+      VARS[i]
+    end
+  }.sort.join(",")
+
+  return "![#{vars_str1}] : ?[#{vars_str11}] : ( " + eq2tptp(surj_lhs, surj_rhs, VARS) + " ) <=> ![#{vars_str2}] : ( (" + eq2tptp(inj1, inj2, VARS) + " ) => " + eq2tptp(inj_final_eq1, inj_final_eq2, VARS) + " )"
+end
+
+# Turn "x = x ◇ y" into ["x", ["x, "y"]]
+def parse_expression(expr)
+  tokens = expr.scan(/◇|\w+|[(),=]/)
+  __parse_eq(tokens)
+end
+
+def __parse_eq(tokens)
+  left = __parse_term(tokens)
+  throw "Bad token!" unless tokens.shift == '='
+  right = __parse_term(tokens)
+  return [left, right]
+end
+
+def __parse_term(tokens)
+  token = tokens.shift
+  if token == '('
+    args = []
+    args << __parse_term(tokens)
+    throw "Bad token!" unless tokens.shift == ')'
+    if tokens.length > 1 && tokens[0] == '◇'
+      throw "Bad token!" unless tokens.shift == '◇'
+      args << __parse_term(tokens)
+      return args
+    else
+      return args[0]
+    end
+  elsif tokens.length > 1 && tokens[0] == '◇'
+    args = []
+    args << token
+    throw "Bad token!" unless tokens.shift == '◇'
+    args << __parse_term(tokens)
+    return args
+  else
+    return token
+  end
+end
+
+# TODO: port
+def find_equation_ids(equations)
+  stdout, stderr, status = Open3.capture3('python', FIND_EQUATION_ID, *equations.map(&:to_s))
+  if status != 0
+    $stderr.puts "Bad result: #{status} #{stdout} #{stderr}"
+    exit 1
+  end
+
+  equations = {}
+  stdout.split("\n").each { |s|
+    if s =~ /Equation (\d+): (.+)/
+      eq_num = $1.to_i
+      eq = parse_expression($2)
+
+      # ["x", "y"] -> [0, 1]
+      vars = eq.flatten.uniq
+      vars.each_with_index { |v, i|
+        eq = subtree_replace(eq, v, i)
+      }
+
+      equations[eq_num] = eq
+    end
+  }
+
+  equations
+end
+
+def find_equation_id(equation)
+  result = find_equation_ids([equation])
+  raise "Unexpected" unless result.keys.length == 1
+  return result.keys[0]
+end
+
+class TreeDoesntMatch < Exception
+end
+
+def __tree_matches_structure(tree, match_tree, assignments={})
+  if match_tree.class != Array
+    if assignments[match_tree] && assignments[match_tree] != tree
+      raise TreeDoesntMatch.new
+    end
+    assignments[match_tree] = tree
+    return
+  end
+
+  if tree.class != Array
+    raise TreeDoesntMatch.new
+  end
+
+  __tree_matches_structure(tree[0], match_tree[0], assignments)
+  __tree_matches_structure(tree[1], match_tree[1], assignments)
+end
+
+# (xy)(xy) matches (xx), but (xy) does not
+def tree_matches_structure(tree, match_tree)
+  begin
+    __tree_matches_structure(tree, match_tree)
+    return true
+  rescue TreeDoesntMatch
+    return false
+  end
+end
+
+def renumber_rhs(lhs, rhs)
+  remap = {}
+  bound = [lhs].flatten.uniq
+  bound.each { |v| remap[v] = v }
+
+  high = bound.max
+  rhs.flatten.each { |v|
+    if !remap[v]
+      high += 1
+      remap[v] = high
+    end
+  }
+
+  remap.each { |k, v|
+    next if k == v
+    rhs = subtree_replace(rhs, k, -v)
+  }
+  remap.each { |k, v|
+    next if k == v
+    rhs = subtree_replace(rhs, -v, v)
+  }
+
+  return rhs
+end
+
+# Some test cases to remember for the future: 35086954397121969570, 48337705565069
+def find_inverses(eq)
+  lhs, rhs = eq
+
+  seen_rhs = Set.new([rhs])
+  inverses = []
+  match_expr = lhs
+  loop {
+    results = subtree_search(rhs, match_expr)
+    break if results.length == 0
+    if results.uniq.length > 1
+      # This may be nested, e.g. x=y((x(xy))y) so continue trying, but start at the smallest element (e.g. for eq 124)
+      match_expr = results.sort_by { |r| r.flatten.length }[0]
+      next
+    end
+
+    sub_expr = results[0]
+    match_expr = sub_expr
+
+    break if sub_expr == rhs
+    next if sub_expr.flatten.length == 1
+
+    operation = subtree_replace(sub_expr, lhs, "s")
+    inv_operation = subtree_replace(rhs, sub_expr, "s")
+    next if [inv_operation, operation].flatten & [lhs].flatten != []
+
+    # For example, if the LHS is x ◇ x then the operations must also match, e.g. as in equation 48337705565069
+    next if !tree_matches_structure(operation, lhs) || !tree_matches_structure(inv_operation, lhs)
+
+    inverted_rhs = subtree_replace(operation, "s", subtree_replace(inv_operation, "s", lhs))
+    next if inverted_rhs == rhs
+
+    # Equation 19, X = (Y ◇ (Z ◇ X))), is transformed into X = (Z ◇ (Y ◇ X)) which is equivalent,
+    # except for numbering. This checks for this case, but we don't want to use it further
+    # as it conflicts with the variable declarations in operation/inv_operation
+    renumbered = renumber_rhs(lhs, inverted_rhs)
+    next if seen_rhs.include? renumbered
+    seen_rhs.add(renumbered)
+
+    inverses.push({
+      operation: operation,
+      inv_operation: inv_operation,
+      inverted: [lhs, inverted_rhs]
+    })
+  }
+
+  return inverses
+end
+
+options = {}
+opt_parser= OptionParser.new do |opt|
+  opt.banner = "Usage: generate_tptp [options] <output directory>"
+
+  opt.on('--inverses', 'Include axioms for inverses')
+  opt.on('--generate-test-inverses LOW-HIGH', 'Generate proofs of inverses for all equations in the given range, intended for testing the correctness of the inverses code')
+
+  opt.on('--simple-bijections', 'Include simple bijective axioms')
+  opt.on('--bruteforce-bijections1 LHS,RHS', 'Bruteforce bijections by number of terms on LHS/RHS')
+
+  opt.on('--bruteforce-periodicity-heuristic', 'Generates axioms to test if this implication may be subject to proof using a periodicity heuristic as mentioned here: https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/Austin.20pairs/near/483445305')
+end
+
+opt_parser.parse!(into: options)
+
+if options[:"generate-test-inverses"]
+  low, high = options[:"generate-test-inverses"].split("-").map(&:to_i)
+  equations = find_equation_ids(low.upto(high).to_a)
+
+  puts <<-END
+import equational_theories.MagmaOp
+import Mathlib.Data.Set.Finite.Basic
+
+set_option linter.unusedVariables false
+
+END
+
+  inverses = {}
+  equations.each { |eqnum, eqtree|
+    r = find_inverses(eqtree)
+    next if r.length == 0
+
+    inverses[[eqnum, eqtree]] = r
+  }
+
+  inverse_eqs = find_equation_ids(inverses.values.flatten.map { |i| eq_repr i[:inverted] })
+  reverse_inverse_eqs = {}
+  inverse_eqs.each { |k, v| reverse_inverse_eqs[v] = k }
+
+  inverses.each { |d, invs|
+    eqnum, eqtree = d
+    invs.each { |inv|
+      renumbered = [inv[:inverted][0], renumber_rhs(*inv[:inverted])]
+      inverted_eqnum = reverse_inverse_eqs[renumbered]
+      raise "Unexpected" if !inverted_eqnum
+
+      puts "theorem Finite.Equation#{eqnum}_implies_inverse_Equation#{inverted_eqnum} (G: Type _) [Magma G] [Finite G] (h : #{leanify_eq(eqtree)}) : #{leanify_eq(inv[:inverted])} := by"
+      #puts "theorem Finite.Equation#{eqnum}_implies_inverse_Equation#{inverted_eqnum} (G: Type _) [Magma G] [Finite G] (h : Equation#{eqnum} G) : Equation#{inverted_eqnum} G := by"
+      puts leanify_inverse(inv[:operation], inv[:inv_operation], inv[:inverted]).gsub("REPLACE", "result")
+      puts "  simp [result]"
+      puts
+    }
+  }
+
+  exit 0
+end
+
+if ARGV.length != 1
+  $stderr.puts "Missing arguments"
+  $stderr.puts opt_parser
+  exit 1
+end
 
 begin
-  Dir.mkdir(ARGV[1])
+  Dir.mkdir(ARGV[0])
 rescue Errno::EEXIST
-  puts "output directory already exists, move it aside or delete it"
+  $stderr.puts "Output directory already exists, move it aside or delete it"
   exit 1
 end
 
-$unknowns = {}
+seen_eqs = Set.new
+unknowns = {}
 while $stdin.gets
   src, dst = $_.split(",").map(&:to_i)
-  $unknowns[src] ||= []
-  $unknowns[src] << dst
+  unknowns[src] ||= []
+  unknowns[src] << dst
+  seen_eqs.add(src)
+  seen_eqs.add(dst)
 end
 
-$equations.each { |src_eq, e|
-  #next if src_eq > 4694
+equations = find_equation_ids(seen_eqs.to_a)
+equations.each { |src_eq, e|
+  next if !unknowns[src_eq]
 
-  next if !$unknowns[src_eq]
-  $unknowns[src_eq].each { |dst_eq|
-    src_lhs, src_rhs = simplify_eq($equations[src_eq]["law"])
-    dst_lhs, dst_rhs = simplify_eq($equations[dst_eq]["law"])
+  export = {
+    "hypothesis_num" => src_eq,
+    "finite" => options != {},
+    "axioms" => {}
+  }
 
-    src_vars = [src_lhs, src_rhs].flatten.uniq
-    dst_vars = [dst_lhs, dst_rhs].flatten.uniq
+  axioms_tptp = {}
 
-    i = 1
-    export = {
-      "hypothesis_num" => src_eq,
-      "hypothesis_eq" => [src_lhs, src_rhs],
-      "goal_num" => dst_eq,
-      "goal_eq" => [dst_lhs, dst_rhs],
-      "finite" => true,
-      "axioms" => {}
+  if options[:inverses]
+    inverses = {}
+    find_inverses(equations[src_eq]).each { |inv|
+      # Slow
+      #eqnum = find_equation_id(eq_repr(inv[:inverted]))
+      #name = "inverse_#{eqnum}"
+      name = "inverse_rnd#{inv[:inverted].hash.abs}"
+      export["axioms"][name] = { "proof" => leanify_inverse(inv[:operation], inv[:inv_operation], inv[:inverted]) }
+      axioms_tptp[name] = tptp(inv[:inverted])
     }
-    match_expr = src_lhs
-    loop {
-      results = subtree_search(src_rhs, match_expr)
-      break if results.length == 0
-      if results.uniq.length > 1
-        # This may be nested, e.g. x=y((x(xy))y) so continue trying, but start at the smallest element (e.g. for eq 124)
-        match_expr = results.sort_by { |r| r.flatten.length }[0]
-        next
-      end
+  end
 
-      sub_expr = results[0]
-      match_expr = sub_expr
+  if options[:"simple-bijections"]
+    SIMPLE_BIJECTIONS.each { |name, tptp|
+      export["axioms"][name] = { "proof" => "Not implemented" }
+      axioms_tptp[name] = tptp
+    }
+  end
 
-      break if sub_expr == src_rhs
+  unknowns[src_eq].each { |dst_eq|
+    export["goal_num"] = dst_eq
+    export["goal_eq"] = equations[dst_eq]
+    base_tptp = <<-END
+% JSON: #{JSON.generate(export)}
+%---- #{src_eq} => #{dst_eq}
+fof(hypothesis, axiom, #{tptp(equations[src_eq])} ).
+fof(goal, conjecture, #{tptp(equations[dst_eq])} ).
+END
 
-      operation = subtree_replace(sub_expr, src_lhs, "s")
-      inv_operation = subtree_replace(src_rhs, sub_expr, "s")
-
-      next if [inv_operation, operation].flatten & [src_lhs].flatten != []
-
-      inverted = subtree_replace(operation, "s", subtree_replace(inv_operation, "s", src_lhs))
-      
-      name = "inverse#{i}"
-      i += 1
-      export["axioms"][name] = {
-        "eq" => [src_lhs, inverted],
-        "proof" => leanify_inverse(src_lhs, operation, inv_operation, [src_lhs, inverted]),
+    if options[:"bruteforce-bijections1"]
+      l, r = options[:"bruteforce-bijections1"].split(",").map(&:to_i)
+      gen_equations(l, r) { |axiom_num, lhs, rhs|
+        bf_fof = gen_bij_tptp(lhs, rhs)
+        if bf_fof
+          File.open(File.join(ARGV[0], "#{src_eq}_#{dst_eq}_axiom#{axiom_num}.p"), "w") { |f|
+            f.puts base_tptp
+            axioms_tptp.each { |name, tptp|
+              f.puts "fof(#{name}, axiom, " + tptp + ")."
+            }
+            f.puts "fof(try, axiom, #{bf_fof} )."
+          }
+        end
       }
-    }
+    elsif options[:"bruteforce-periodicity-heuristic"]
+      expr_idx = 1
+      #call_on_every_subtree(equations[dst_eq][1]) { |rhs|
+      gen_equations(1, 4) { |axiom_num, lhs, rhs|
+        next if rhs.class != Array
+        next if [rhs].flatten.uniq.length != 1
 
-    File.open(File.join(ARGV[1], "#{src_eq}_#{dst_eq}.p"), "w") { |f|
-      f.puts "% JSON: #{JSON.generate(export)}"
-      f.puts "%---- #{src_eq} => #{dst_eq}"
-      f.puts "fof(hypothesis, axiom, " + tptp([src_lhs, src_rhs]) + ")."
-      f.puts "fof(goal, conjecture, " + tptp([dst_lhs, dst_rhs]) + ")."
-      export["axioms"].each { |k, v|
-        f.puts "fof(#{k}, axiom, " + tptp(v["eq"]) + ")."
+        # f^[i] = f^[i*j]
+        [
+          [1, 2], [1, 3], [1, 4], [1, 8],
+          [2, 2], [2, 3]
+        ].each { |i, j|
+          File.open(File.join(ARGV[0], "#{src_eq}_#{dst_eq}_expr#{expr_idx}_#{i}_#{j}.p"), "w") { |f|
+            f.puts base_tptp
+
+            f_i = 0
+            i.times { f_i = subtree_replace(f_i, 0, rhs) }
+            f_ij = 0
+            j.times { f_ij = subtree_replace(f_ij, 0, f_i) }
+            f.puts "fof(expr#{expr_idx}_#{i}_#{j}, axiom, #{tptp([f_i, f_ij])} )."
+          }
+        }
+
+        expr_idx += 1
       }
-    }
+    else
+      File.open(File.join(ARGV[0], "#{src_eq}_#{dst_eq}.p"), "w") { |f|
+        f.puts base_tptp
+        axioms_tptp.each { |name, tptp|
+          f.puts "fof(#{name}, axiom, " + tptp + ")."
+        }
+      }
+    end
   }
 }

--- a/equational_theories/Generated/FiniteImplicationSearch/theorems/Inverses1.lean
+++ b/equational_theories/Generated/FiniteImplicationSearch/theorems/Inverses1.lean
@@ -12,8 +12,9 @@ theorem Finite.Equation1076_implies_Equation3 (G : Type*) [Magma G] [Finite G] (
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq9 (X0 X1 : G) : (X1 ◇ ((X0 ◇ (X0 ◇ X1)) ◇ X1)) = X0 := mod_symm (h ..)
-  have eq10 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ ((Y ◇ (X ◇ Y)) ◇ Y)) = X := by
+  have step9 (X0 X1 : G) : (X1 ◇ ((X0 ◇ (X0 ◇ X1)) ◇ X1)) = X0 := mod_symm (h ..)
+  have step10 : sK0 ≠ (sK0 ◇ sK0) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ ((Y ◇ (X ◇ Y)) ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (s ◇ Y))) S := by
       intro
@@ -30,7 +31,7 @@ theorem Finite.Equation1076_implies_Equation3 (G : Type*) [Magma G] [Finite G] (
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq11 (X Y : G) : (((Y ◇ X) ◇ ((Y ◇ X) ◇ Y)) ◇ Y) = X := by
+  have step12 (X Y : G) : (((Y ◇ X) ◇ ((Y ◇ X) ◇ Y)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => ((s ◇ (s ◇ Y)) ◇ Y)) S := by
       intro
@@ -47,16 +48,15 @@ theorem Finite.Equation1076_implies_Equation3 (G : Type*) [Magma G] [Finite G] (
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (sK0 ◇ sK0) := mod_symm nh
-  have eq13 (X0 X1 : G) : (((X0 ◇ (X0 ◇ X1)) ◇ X1) ◇ ((X1 ◇ X0) ◇ ((X0 ◇ (X0 ◇ X1)) ◇ X1))) = X1 := superpose eq9 eq9
-  have eq15 (X0 X1 : G) : ((X1 ◇ X0) ◇ ((X1 ◇ X0) ◇ X1)) = (X1 ◇ ((((X1 ◇ X0) ◇ ((X1 ◇ X0) ◇ X1)) ◇ X0) ◇ X1)) := superpose eq11 eq9
-  have eq75 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ X0)) = (X0 ◇ (X0 ◇ X0)) := superpose eq11 eq15
-  have eq91 (X0 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ X0) = X0 := superpose eq75 eq11
-  have eq92 (X0 : G) : (((X0 ◇ (X0 ◇ X0)) ◇ X0) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ X0))) = X0 := superpose eq75 eq13
-  have eq102 (X0 : G) : (((X0 ◇ (X0 ◇ X0)) ◇ X0) ◇ X0) = X0 := superpose eq10 eq92
-  have eq103 (X0 : G) : (X0 ◇ X0) = X0 := superpose eq91 eq102
-  have eq175 : sK0 ≠ sK0 := superpose eq103 eq12
-  subsumption eq175 rfl
+  have step13 (X0 X1 : G) : (((X0 ◇ (X0 ◇ X1)) ◇ X1) ◇ ((X1 ◇ X0) ◇ ((X0 ◇ (X0 ◇ X1)) ◇ X1))) = X1 := superpose step9 step9
+  have step15 (X0 X1 : G) : ((X1 ◇ X0) ◇ ((X1 ◇ X0) ◇ X1)) = (X1 ◇ ((((X1 ◇ X0) ◇ ((X1 ◇ X0) ◇ X1)) ◇ X0) ◇ X1)) := superpose step12 step9
+  have step75 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ X0)) = (X0 ◇ (X0 ◇ X0)) := superpose step12 step15
+  have step91 (X0 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ X0) = X0 := superpose step75 step12
+  have step92 (X0 : G) : (((X0 ◇ (X0 ◇ X0)) ◇ X0) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ X0))) = X0 := superpose step75 step13
+  have step102 (X0 : G) : (((X0 ◇ (X0 ◇ X0)) ◇ X0) ◇ X0) = X0 := superpose step11 step92
+  have step103 (X0 : G) : (X0 ◇ X0) = X0 := superpose step91 step102
+  have step175 : sK0 ≠ sK0 := superpose step103 step10
+  subsumption step175 rfl
 
 
 @[equational_result]
@@ -64,7 +64,8 @@ theorem Finite.Equation1086_implies_Equation1832 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq10 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ (Y ◇ Y)) = X := by
+  have step10 : sK0 ≠ ((sK0 ◇ (sK0 ◇ sK0)) ◇ (sK0 ◇ sK0)) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ (Y ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ Y))) S := by
       intro
@@ -81,8 +82,8 @@ theorem Finite.Equation1086_implies_Equation1832 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((sK0 ◇ (sK0 ◇ sK0)) ◇ (sK0 ◇ sK0)) := mod_symm nh
-  subsumption eq12 eq10
+  have step15 : sK0 ≠ sK0 := superpose step11 step10
+  subsumption step15 rfl
 
 
 @[equational_result]
@@ -90,7 +91,8 @@ theorem Finite.Equation1086_implies_Equation1898 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq10 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ (Y ◇ Y)) = X := by
+  have step10 : sK0 ≠ ((sK1 ◇ (sK0 ◇ sK1)) ◇ (sK1 ◇ sK1)) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ (Y ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ Y))) S := by
       intro
@@ -107,8 +109,8 @@ theorem Finite.Equation1086_implies_Equation1898 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((sK1 ◇ (sK0 ◇ sK1)) ◇ (sK1 ◇ sK1)) := mod_symm nh
-  subsumption eq12 eq10
+  have step15 : sK0 ≠ sK0 := superpose step11 step10
+  subsumption step15 rfl
 
 
 @[equational_result]
@@ -116,7 +118,8 @@ theorem Finite.Equation1086_implies_Equation2710 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq11 (X Y : G) : (((Y ◇ X) ◇ (Y ◇ Y)) ◇ Y) = X := by
+  have step10 : sK0 ≠ (((sK1 ◇ sK0) ◇ (sK1 ◇ sK1)) ◇ sK1) := mod_symm nh
+  have step12 (X Y : G) : (((Y ◇ X) ◇ (Y ◇ Y)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => ((s ◇ (Y ◇ Y)) ◇ Y)) S := by
       intro
@@ -133,8 +136,8 @@ theorem Finite.Equation1086_implies_Equation2710 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (((sK1 ◇ sK0) ◇ (sK1 ◇ sK1)) ◇ sK1) := mod_symm nh
-  subsumption eq12 eq11
+  have step17 : sK0 ≠ sK0 := superpose step12 step10
+  subsumption step17 rfl
 
 
 @[equational_result]
@@ -142,7 +145,8 @@ theorem Finite.Equation1110_implies_Equation8 (G : Type*) [Magma G] [Finite G] (
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq11 (X Y : G) : ((Y ◇ ((Y ◇ X) ◇ Y)) ◇ (Y ◇ ((Y ◇ X) ◇ Y))) = X := by
+  have step11 : sK0 ≠ (sK0 ◇ (sK0 ◇ sK0)) := mod_symm nh
+  have step12 (X Y : G) : ((Y ◇ ((Y ◇ X) ◇ Y)) ◇ (Y ◇ ((Y ◇ X) ◇ Y))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ s)) S := by
       intro
@@ -159,7 +163,7 @@ theorem Finite.Equation1110_implies_Equation8 (G : Type*) [Magma G] [Finite G] (
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq13 (X Y : G) : ((Y ◇ ((Y ◇ X) ◇ (Y ◇ X))) ◇ Y) = X := by
+  have step14 (X Y : G) : ((Y ◇ ((Y ◇ X) ◇ (Y ◇ X))) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => ((Y ◇ (s ◇ s)) ◇ Y)) S := by
       intro
@@ -176,14 +180,13 @@ theorem Finite.Equation1110_implies_Equation8 (G : Type*) [Magma G] [Finite G] (
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : sK0 ≠ (sK0 ◇ (sK0 ◇ sK0)) := mod_symm nh
-  have eq15 (X0 X1 : G) : (((X1 ◇ ((X1 ◇ X0) ◇ (X1 ◇ X0))) ◇ (X0 ◇ X0)) ◇ (X1 ◇ ((X1 ◇ X0) ◇ (X1 ◇ X0)))) = X1 := superpose eq13 eq13
-  have eq74 (X0 : G) : (X0 ◇ X0) = (X0 ◇ ((X0 ◇ X0) ◇ (((X0 ◇ X0) ◇ X0) ◇ ((X0 ◇ X0) ◇ X0)))) := superpose eq13 eq15
-  have eq160 (X0 : G) : ((X0 ◇ X0) ◇ (((X0 ◇ X0) ◇ X0) ◇ ((X0 ◇ X0) ◇ X0))) = ((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ (X0 ◇ ((X0 ◇ X0) ◇ X0))) := superpose eq74 eq11
-  have eq167 (X0 : G) : ((X0 ◇ X0) ◇ (((X0 ◇ X0) ◇ X0) ◇ ((X0 ◇ X0) ◇ X0))) = X0 := superpose eq11 eq160
-  have eq201 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = X0 := superpose eq167 eq13
-  have eq244 : sK0 ≠ sK0 := superpose eq201 eq14
-  subsumption eq244 rfl
+  have step15 (X0 X1 : G) : (((X1 ◇ ((X1 ◇ X0) ◇ (X1 ◇ X0))) ◇ (X0 ◇ X0)) ◇ (X1 ◇ ((X1 ◇ X0) ◇ (X1 ◇ X0)))) = X1 := superpose step14 step14
+  have step74 (X0 : G) : (X0 ◇ X0) = (X0 ◇ ((X0 ◇ X0) ◇ (((X0 ◇ X0) ◇ X0) ◇ ((X0 ◇ X0) ◇ X0)))) := superpose step14 step15
+  have step160 (X0 : G) : ((X0 ◇ X0) ◇ (((X0 ◇ X0) ◇ X0) ◇ ((X0 ◇ X0) ◇ X0))) = ((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ (X0 ◇ ((X0 ◇ X0) ◇ X0))) := superpose step74 step12
+  have step167 (X0 : G) : ((X0 ◇ X0) ◇ (((X0 ◇ X0) ◇ X0) ◇ ((X0 ◇ X0) ◇ X0))) = X0 := superpose step12 step160
+  have step201 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = X0 := superpose step167 step14
+  have step244 : sK0 ≠ sK0 := superpose step201 step11
+  subsumption step244 rfl
 
 
 @[equational_result]
@@ -191,8 +194,9 @@ theorem Finite.Equation1112_implies_Equation8 (G : Type*) [Magma G] [Finite G] (
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq8 (X0 X1 : G) : (X1 ◇ ((X1 ◇ (X0 ◇ X1)) ◇ X0)) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : ((Y ◇ ((Y ◇ X) ◇ Y)) ◇ (Y ◇ X)) = X := by
+  have step8 (X0 X1 : G) : (X1 ◇ ((X1 ◇ (X0 ◇ X1)) ◇ X0)) = X0 := mod_symm (h ..)
+  have step9 : sK0 ≠ (sK0 ◇ (sK0 ◇ sK0)) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ ((Y ◇ X) ◇ Y)) ◇ (Y ◇ X)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => ((Y ◇ (s ◇ Y)) ◇ s)) S := by
       intro
@@ -209,12 +213,11 @@ theorem Finite.Equation1112_implies_Equation8 (G : Type*) [Magma G] [Finite G] (
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ (sK0 ◇ (sK0 ◇ sK0)) := mod_symm nh
-  have eq13 (X0 : G) : (X0 ◇ X0) = (X0 ◇ (X0 ◇ (X0 ◇ X0))) := superpose eq8 eq9
-  have eq16 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ (X0 ◇ X0)) := superpose eq13 eq9
-  have eq18 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = X0 := superpose eq9 eq16
-  have eq20 : sK0 ≠ sK0 := superpose eq18 eq10
-  subsumption eq20 rfl
+  have step13 (X0 : G) : (X0 ◇ X0) = (X0 ◇ (X0 ◇ (X0 ◇ X0))) := superpose step8 step10
+  have step16 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ (X0 ◇ X0)) := superpose step13 step10
+  have step18 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = X0 := superpose step10 step16
+  have step20 : sK0 ≠ sK0 := superpose step18 step9
+  subsumption step20 rfl
 
 
 @[equational_result]
@@ -222,7 +225,8 @@ theorem Finite.Equation1113_implies_Equation2534 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq11 (X Y : G) : ((Y ◇ ((Y ◇ X) ◇ Y)) ◇ Y) = X := by
+  have step9 : sK0 ≠ ((sK1 ◇ ((sK1 ◇ sK0) ◇ sK1)) ◇ sK1) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ ((Y ◇ X) ◇ Y)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -239,8 +243,8 @@ theorem Finite.Equation1113_implies_Equation2534 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : sK0 ≠ ((sK1 ◇ ((sK1 ◇ sK0) ◇ sK1)) ◇ sK1) := mod_symm nh
-  subsumption eq14 eq11
+  have step13 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step13 rfl
 
 
 @[equational_result]
@@ -248,7 +252,8 @@ theorem Finite.Equation1117_implies_Equation2538 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, sK2, nh⟩ := nh
-  have eq11 (X Y Z : G) : ((Y ◇ ((Y ◇ X) ◇ Z)) ◇ Z) = X := by
+  have step9 : sK0 ≠ ((sK1 ◇ ((sK1 ◇ sK0) ◇ sK2)) ◇ sK2) := mod_symm nh
+  have step10 (X Y Z : G) : ((Y ◇ ((Y ◇ X) ◇ Z)) ◇ Z) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Z)) S := by
       intro
@@ -265,8 +270,8 @@ theorem Finite.Equation1117_implies_Equation2538 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : sK0 ≠ ((sK1 ◇ ((sK1 ◇ sK0) ◇ sK2)) ◇ sK2) := mod_symm nh
-  subsumption eq14 eq11
+  have step15 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step15 rfl
 
 
 @[equational_result]
@@ -274,7 +279,8 @@ theorem Finite.Equation115_implies_Equation2707 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq11 (X Y : G) : (((Y ◇ X) ◇ (Y ◇ X)) ◇ Y) = X := by
+  have step10 : sK0 ≠ (((sK1 ◇ sK0) ◇ (sK1 ◇ sK0)) ◇ sK1) := mod_symm nh
+  have step12 (X Y : G) : (((Y ◇ X) ◇ (Y ◇ X)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => ((s ◇ s) ◇ Y)) S := by
       intro
@@ -291,8 +297,8 @@ theorem Finite.Equation115_implies_Equation2707 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (((sK1 ◇ sK0) ◇ (sK1 ◇ sK0)) ◇ sK1) := mod_symm nh
-  subsumption eq12 eq11
+  have step15 : sK0 ≠ sK0 := superpose step12 step10
+  subsumption step15 rfl
 
 
 @[equational_result]
@@ -300,8 +306,9 @@ theorem Finite.Equation115_implies_Equation4273 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X0 X1 : G) : (X1 ◇ ((X0 ◇ X0) ◇ X1)) = X0 := mod_symm (h ..)
-  have eq10 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ (Y ◇ (X ◇ Y))) = X := by
+  have step9 (X0 X1 : G) : (X1 ◇ ((X0 ◇ X0) ◇ X1)) = X0 := mod_symm (h ..)
+  have step10 : (sK0 ◇ (sK0 ◇ sK0)) ≠ (sK1 ◇ (sK0 ◇ sK1)) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ (Y ◇ (X ◇ Y))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ s)) S := by
       intro
@@ -318,10 +325,9 @@ theorem Finite.Equation115_implies_Equation4273 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : (sK1 ◇ (sK0 ◇ sK1)) ≠ (sK0 ◇ (sK0 ◇ sK0)) := mod_symm nh
-  have eq17 (X0 X1 X2 : G) : (X1 ◇ (X0 ◇ X1)) = (X2 ◇ (X0 ◇ X2)) := superpose eq10 eq9
-  have eq49 (X0 : G) : (sK0 ◇ (sK0 ◇ sK0)) ≠ (X0 ◇ (sK0 ◇ X0)) := superpose eq17 eq12
-  subsumption eq49 eq17
+  have step17 (X0 X1 X2 : G) : (X1 ◇ (X0 ◇ X1)) = (X2 ◇ (X0 ◇ X2)) := superpose step11 step9
+  have step49 (X0 : G) : (sK0 ◇ (sK0 ◇ sK0)) ≠ (X0 ◇ (sK0 ◇ X0)) := superpose step17 step10
+  subsumption step49 step17
 
 
 @[equational_result]
@@ -329,7 +335,8 @@ theorem Finite.Equation118_implies_Equation222 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq10 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ Y) = X := by
+  have step10 : sK0 ≠ ((sK1 ◇ (sK0 ◇ sK1)) ◇ sK1) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -346,8 +353,8 @@ theorem Finite.Equation118_implies_Equation222 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((sK1 ◇ (sK0 ◇ sK1)) ◇ sK1) := mod_symm nh
-  subsumption eq12 eq10
+  have step16 : sK0 ≠ sK0 := superpose step11 step10
+  subsumption step16 rfl
 
 
 @[equational_result]
@@ -355,33 +362,8 @@ theorem Finite.Equation118_implies_Equation274 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq11 (X Y : G) : (((Y ◇ X) ◇ Y) ◇ Y) = X := by
-    let S : Set G := Set.univ
-    have m1 : S.MapsTo (fun s => ((s ◇ Y) ◇ Y)) S := by
-      intro
-      simp [S]
-    have m2 : S.MapsTo (fun s => (Y ◇ s)) S := by
-      intro
-      simp [S]
-    have linv : S.LeftInvOn (fun s => (Y ◇ s)) (fun s => ((s ◇ Y) ◇ Y)) := by
-      intro a ha
-      simp [S]
-      simp [← h]
-    have t := linv.surjOn m1
-    rw [Set.Finite.surjOn_iff_bijOn_of_mapsTo (Set.toFinite _) m2] at t
-    have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
-    apply rinv _
-    simp [S]
-  have eq12 : sK0 ≠ (((sK1 ◇ sK0) ◇ sK1) ◇ sK1) := mod_symm nh
-  subsumption eq12 eq11
-
-
-@[equational_result]
-theorem Finite.Equation118_implies_Equation4435 (G : Type*) [Magma G] [Finite G] (h : Equation118 G) : Equation4435 G := by
-  by_contra nh
-  simp only [not_forall] at nh
-  obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq10 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ Y) = X := by
+  have step10 : sK0 ≠ (((sK1 ◇ sK0) ◇ sK1) ◇ sK1) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -398,10 +380,37 @@ theorem Finite.Equation118_implies_Equation4435 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : (sK0 ◇ (sK1 ◇ sK0)) ≠ ((sK0 ◇ sK1) ◇ sK0) := mod_symm nh
-  have eq15 (X0 X1 : G) : (X1 ◇ (X0 ◇ X1)) = ((X1 ◇ X0) ◇ X1) := superpose eq10 eq10
-  have eq25 : (sK0 ◇ (sK1 ◇ sK0)) ≠ (sK0 ◇ (sK1 ◇ sK0)) := superpose eq15 eq12
-  subsumption eq25 rfl
+  have step15 (X0 X1 : G) : ((X1 ◇ X0) ◇ X1) = (X1 ◇ (X0 ◇ X1)) := superpose step11 step11
+  have step17 : sK0 ≠ ((sK1 ◇ (sK0 ◇ sK1)) ◇ sK1) := superpose step15 step10
+  subsumption step17 step11
+
+
+@[equational_result]
+theorem Finite.Equation118_implies_Equation4435 (G : Type*) [Magma G] [Finite G] (h : Equation118 G) : Equation4435 G := by
+  by_contra nh
+  simp only [not_forall] at nh
+  obtain ⟨sK0, sK1, nh⟩ := nh
+  have step10 : (sK0 ◇ (sK1 ◇ sK0)) ≠ ((sK0 ◇ sK1) ◇ sK0) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (X ◇ Y)) ◇ Y) = X := by
+    let S : Set G := Set.univ
+    have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
+      intro
+      simp [S]
+    have m2 : S.MapsTo (fun s => (Y ◇ (s ◇ Y))) S := by
+      intro
+      simp [S]
+    have linv : S.LeftInvOn (fun s => (Y ◇ (s ◇ Y))) (fun s => (s ◇ Y)) := by
+      intro a ha
+      simp [S]
+      simp [← h]
+    have t := linv.surjOn m1
+    rw [Set.Finite.surjOn_iff_bijOn_of_mapsTo (Set.toFinite _) m2] at t
+    have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
+    apply rinv _
+    simp [S]
+  have step15 (X0 X1 : G) : (X1 ◇ (X0 ◇ X1)) = ((X1 ◇ X0) ◇ X1) := superpose step11 step11
+  have step25 : (sK0 ◇ (sK1 ◇ sK0)) ≠ (sK0 ◇ (sK1 ◇ sK0)) := superpose step15 step10
+  subsumption step25 rfl
 
 
 @[equational_result]
@@ -409,8 +418,9 @@ theorem Finite.Equation1276_implies_Equation4273 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X0 X1 : G) : (X1 ◇ (((X0 ◇ X0) ◇ X0) ◇ X1)) = X0 := mod_symm (h ..)
-  have eq10 (X Y : G) : (((Y ◇ (X ◇ Y)) ◇ (Y ◇ (X ◇ Y))) ◇ (Y ◇ (X ◇ Y))) = X := by
+  have step9 (X0 X1 : G) : (X1 ◇ (((X0 ◇ X0) ◇ X0) ◇ X1)) = X0 := mod_symm (h ..)
+  have step10 : (sK0 ◇ (sK0 ◇ sK0)) ≠ (sK1 ◇ (sK0 ◇ sK1)) := mod_symm nh
+  have step11 (X Y : G) : (((Y ◇ (X ◇ Y)) ◇ (Y ◇ (X ◇ Y))) ◇ (Y ◇ (X ◇ Y))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => ((s ◇ s) ◇ s)) S := by
       intro
@@ -427,10 +437,9 @@ theorem Finite.Equation1276_implies_Equation4273 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : (sK1 ◇ (sK0 ◇ sK1)) ≠ (sK0 ◇ (sK0 ◇ sK0)) := mod_symm nh
-  have eq17 (X0 X1 X2 : G) : (X1 ◇ (X0 ◇ X1)) = (X2 ◇ (X0 ◇ X2)) := superpose eq10 eq9
-  have eq40 (X0 : G) : (sK0 ◇ (sK0 ◇ sK0)) ≠ (X0 ◇ (sK0 ◇ X0)) := superpose eq17 eq12
-  subsumption eq40 eq17
+  have step17 (X0 X1 X2 : G) : (X1 ◇ (X0 ◇ X1)) = (X2 ◇ (X0 ◇ X2)) := superpose step11 step9
+  have step40 (X0 : G) : (sK0 ◇ (sK0 ◇ sK0)) ≠ (X0 ◇ (sK0 ◇ X0)) := superpose step17 step10
+  subsumption step40 step17
 
 
 @[equational_result]
@@ -438,7 +447,8 @@ theorem Finite.Equation1289_implies_Equation2507 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq11 (X Y : G) : ((Y ◇ ((X ◇ Y) ◇ Y)) ◇ Y) = X := by
+  have step11 : sK0 ≠ ((sK1 ◇ ((sK0 ◇ sK1) ◇ sK1)) ◇ sK1) := mod_symm nh
+  have step12 (X Y : G) : ((Y ◇ ((X ◇ Y) ◇ Y)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -455,8 +465,8 @@ theorem Finite.Equation1289_implies_Equation2507 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : sK0 ≠ ((sK1 ◇ ((sK0 ◇ sK1) ◇ sK1)) ◇ sK1) := mod_symm nh
-  subsumption eq14 eq11
+  have step18 : sK0 ≠ sK0 := superpose step12 step11
+  subsumption step18 rfl
 
 
 @[equational_result]
@@ -464,7 +474,8 @@ theorem Finite.Equation1289_implies_Equation3116 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq13 (X Y : G) : ((((Y ◇ X) ◇ Y) ◇ Y) ◇ Y) = X := by
+  have step11 : sK0 ≠ ((((sK1 ◇ sK0) ◇ sK1) ◇ sK1) ◇ sK1) := mod_symm nh
+  have step14 (X Y : G) : ((((Y ◇ X) ◇ Y) ◇ Y) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (((s ◇ Y) ◇ Y) ◇ Y)) S := by
       intro
@@ -481,8 +492,8 @@ theorem Finite.Equation1289_implies_Equation3116 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : sK0 ≠ ((((sK1 ◇ sK0) ◇ sK1) ◇ sK1) ◇ sK1) := mod_symm nh
-  subsumption eq14 eq13
+  have step21 : sK0 ≠ sK0 := superpose step14 step11
+  subsumption step21 rfl
 
 
 @[equational_result]
@@ -490,8 +501,9 @@ theorem Finite.Equation1289_implies_Equation4435 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq10 (X0 X1 : G) : (X1 ◇ (((X0 ◇ X1) ◇ X1) ◇ X1)) = X0 := mod_symm (h ..)
-  have eq13 (X Y : G) : ((((Y ◇ X) ◇ Y) ◇ Y) ◇ Y) = X := by
+  have step10 (X0 X1 : G) : (X1 ◇ (((X0 ◇ X1) ◇ X1) ◇ X1)) = X0 := mod_symm (h ..)
+  have step11 : (sK0 ◇ (sK1 ◇ sK0)) ≠ ((sK0 ◇ sK1) ◇ sK0) := mod_symm nh
+  have step14 (X Y : G) : ((((Y ◇ X) ◇ Y) ◇ Y) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (((s ◇ Y) ◇ Y) ◇ Y)) S := by
       intro
@@ -508,10 +520,9 @@ theorem Finite.Equation1289_implies_Equation4435 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : (sK0 ◇ (sK1 ◇ sK0)) ≠ ((sK0 ◇ sK1) ◇ sK0) := mod_symm nh
-  have eq21 (X0 X1 : G) : (X1 ◇ (X0 ◇ X1)) = ((X1 ◇ X0) ◇ X1) := superpose eq13 eq10
-  have eq33 : (sK0 ◇ (sK1 ◇ sK0)) ≠ (sK0 ◇ (sK1 ◇ sK0)) := superpose eq21 eq14
-  subsumption eq33 rfl
+  have step21 (X0 X1 : G) : (X1 ◇ (X0 ◇ X1)) = ((X1 ◇ X0) ◇ X1) := superpose step14 step10
+  have step33 : (sK0 ◇ (sK1 ◇ sK0)) ≠ (sK0 ◇ (sK1 ◇ sK0)) := superpose step21 step11
+  subsumption step33 rfl
 
 
 @[equational_result]
@@ -519,8 +530,9 @@ theorem Finite.Equation1431_implies_Equation1428 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq8 (X0 X1 : G) : ((X0 ◇ X0) ◇ (X1 ◇ (X0 ◇ X0))) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : ((X ◇ (Y ◇ X)) ◇ (X ◇ (Y ◇ X))) = X := by
+  have step8 (X0 X1 : G) : ((X0 ◇ X0) ◇ (X1 ◇ (X0 ◇ X0))) = X0 := mod_symm (h ..)
+  have step9 : sK0 ≠ ((sK0 ◇ sK0) ◇ (sK0 ◇ (sK1 ◇ sK0))) := mod_symm nh
+  have step10 (X Y : G) : ((X ◇ (Y ◇ X)) ◇ (X ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ s)) S := by
       intro
@@ -537,11 +549,10 @@ theorem Finite.Equation1431_implies_Equation1428 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((sK0 ◇ sK0) ◇ (sK0 ◇ (sK1 ◇ sK0))) := mod_symm nh
-  have eq14 (X0 X1 X2 : G) : (X0 ◇ (X1 ◇ X0)) = (X0 ◇ (X2 ◇ X0)) := superpose eq9 eq8
-  have eq29 (X0 : G) : sK0 ≠ ((sK0 ◇ sK0) ◇ (sK0 ◇ (X0 ◇ sK0))) := superpose eq14 eq10
-  have eq41 : sK0 ≠ sK0 := superpose eq8 eq29
-  subsumption eq41 rfl
+  have step14 (X0 X1 X2 : G) : (X0 ◇ (X1 ◇ X0)) = (X0 ◇ (X2 ◇ X0)) := superpose step10 step8
+  have step29 (X0 : G) : sK0 ≠ ((sK0 ◇ sK0) ◇ (sK0 ◇ (X0 ◇ sK0))) := superpose step14 step9
+  have step41 : sK0 ≠ sK0 := superpose step8 step29
+  subsumption step41 rfl
 
 
 @[equational_result]
@@ -549,8 +560,9 @@ theorem Finite.Equation1431_implies_Equation4269 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq8 (X0 X1 : G) : ((X0 ◇ X0) ◇ (X1 ◇ (X0 ◇ X0))) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : ((X ◇ (Y ◇ X)) ◇ (X ◇ (Y ◇ X))) = X := by
+  have step8 (X0 X1 : G) : ((X0 ◇ X0) ◇ (X1 ◇ (X0 ◇ X0))) = X0 := mod_symm (h ..)
+  have step9 : (sK0 ◇ (sK0 ◇ sK0)) ≠ (sK0 ◇ (sK1 ◇ sK0)) := mod_symm nh
+  have step10 (X Y : G) : ((X ◇ (Y ◇ X)) ◇ (X ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ s)) S := by
       intro
@@ -567,10 +579,9 @@ theorem Finite.Equation1431_implies_Equation4269 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : (sK0 ◇ (sK1 ◇ sK0)) ≠ (sK0 ◇ (sK0 ◇ sK0)) := mod_symm nh
-  have eq14 (X0 X1 X2 : G) : (X0 ◇ (X1 ◇ X0)) = (X0 ◇ (X2 ◇ X0)) := superpose eq9 eq8
-  have eq33 (X0 : G) : (sK0 ◇ (sK0 ◇ sK0)) ≠ (sK0 ◇ (X0 ◇ sK0)) := superpose eq14 eq10
-  subsumption eq33 eq14
+  have step14 (X0 X1 X2 : G) : (X0 ◇ (X1 ◇ X0)) = (X0 ◇ (X2 ◇ X0)) := superpose step10 step8
+  have step33 (X0 : G) : (sK0 ◇ (sK0 ◇ sK0)) ≠ (sK0 ◇ (X0 ◇ sK0)) := superpose step14 step9
+  subsumption step33 step14
 
 
 @[equational_result]
@@ -578,7 +589,8 @@ theorem Finite.Equation1491_implies_Equation65 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X Y : G) : (Y ◇ (X ◇ (Y ◇ X))) = X := by
+  have step9 : sK0 ≠ (sK1 ◇ (sK0 ◇ (sK1 ◇ sK0))) := mod_symm nh
+  have step10 (X Y : G) : (Y ◇ (X ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (Y ◇ s)) S := by
       intro
@@ -595,8 +607,8 @@ theorem Finite.Equation1491_implies_Equation65 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ (sK1 ◇ (sK0 ◇ (sK1 ◇ sK0))) := mod_symm nh
-  subsumption eq10 eq9
+  have step12 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step12 rfl
 
 
 @[equational_result]
@@ -604,8 +616,9 @@ theorem Finite.Equation1515_implies_Equation4590 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq8 (X0 X1 : G) : ((X1 ◇ X1) ◇ (X0 ◇ (X0 ◇ X0))) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : (((Y ◇ Y) ◇ X) ◇ (((Y ◇ Y) ◇ X) ◇ ((Y ◇ Y) ◇ X))) = X := by
+  have step8 (X0 X1 : G) : ((X1 ◇ X1) ◇ (X0 ◇ (X0 ◇ X0))) = X0 := mod_symm (h ..)
+  have step9 : ((sK0 ◇ sK0) ◇ sK0) ≠ ((sK1 ◇ sK1) ◇ sK0) := mod_symm nh
+  have step10 (X Y : G) : (((Y ◇ Y) ◇ X) ◇ (((Y ◇ Y) ◇ X) ◇ ((Y ◇ Y) ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (s ◇ s))) S := by
       intro
@@ -622,10 +635,9 @@ theorem Finite.Equation1515_implies_Equation4590 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : ((sK1 ◇ sK1) ◇ sK0) ≠ ((sK0 ◇ sK0) ◇ sK0) := mod_symm nh
-  have eq12 (X0 X1 X2 : G) : ((X1 ◇ X1) ◇ X0) = ((X2 ◇ X2) ◇ X0) := superpose eq9 eq8
-  have eq25 (X0 : G) : ((sK0 ◇ sK0) ◇ sK0) ≠ ((X0 ◇ X0) ◇ sK0) := superpose eq12 eq10
-  subsumption eq25 eq12
+  have step12 (X0 X1 X2 : G) : ((X1 ◇ X1) ◇ X0) = ((X2 ◇ X2) ◇ X0) := superpose step10 step8
+  have step25 (X0 : G) : ((sK0 ◇ sK0) ◇ sK0) ≠ ((X0 ◇ X0) ◇ sK0) := superpose step12 step9
+  subsumption step25 step12
 
 
 @[equational_result]
@@ -633,7 +645,8 @@ theorem Finite.Equation1519_implies_Equation2128 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X Y : G) : (((Y ◇ Y) ◇ X) ◇ (Y ◇ Y)) = X := by
+  have step9 : sK0 ≠ (((sK1 ◇ sK1) ◇ sK0) ◇ (sK1 ◇ sK1)) := mod_symm nh
+  have step10 (X Y : G) : (((Y ◇ Y) ◇ X) ◇ (Y ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ Y))) S := by
       intro
@@ -650,8 +663,8 @@ theorem Finite.Equation1519_implies_Equation2128 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ (((sK1 ◇ sK1) ◇ sK0) ◇ (sK1 ◇ sK1)) := mod_symm nh
-  subsumption eq10 eq9
+  have step13 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step13 rfl
 
 
 @[equational_result]
@@ -659,7 +672,8 @@ theorem Finite.Equation1523_implies_Equation2132 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, sK2, nh⟩ := nh
-  have eq9 (X Y Z : G) : (((Y ◇ Y) ◇ X) ◇ (Z ◇ Z)) = X := by
+  have step9 : sK0 ≠ (((sK1 ◇ sK1) ◇ sK0) ◇ (sK2 ◇ sK2)) := mod_symm nh
+  have step10 (X Y Z : G) : (((Y ◇ Y) ◇ X) ◇ (Z ◇ Z)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Z ◇ Z))) S := by
       intro
@@ -676,8 +690,8 @@ theorem Finite.Equation1523_implies_Equation2132 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ (((sK1 ◇ sK1) ◇ sK0) ◇ (sK2 ◇ sK2)) := mod_symm nh
-  subsumption eq10 eq9
+  have step21 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step21 rfl
 
 
 @[equational_result]
@@ -685,7 +699,8 @@ theorem Finite.Equation1526_implies_Equation1223 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq11 (X Y : G) : (Y ◇ (((Y ◇ Y) ◇ X) ◇ Y)) = X := by
+  have step10 : sK0 ≠ (sK0 ◇ (((sK0 ◇ sK0) ◇ sK0) ◇ sK0)) := mod_symm nh
+  have step12 (X Y : G) : (Y ◇ (((Y ◇ Y) ◇ X) ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (Y ◇ (s ◇ Y))) S := by
       intro
@@ -702,8 +717,8 @@ theorem Finite.Equation1526_implies_Equation1223 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (sK0 ◇ (((sK0 ◇ sK0) ◇ sK0) ◇ sK0)) := mod_symm nh
-  subsumption eq12 eq11
+  have step19 : sK0 ≠ sK0 := superpose step12 step10
+  subsumption step19 rfl
 
 
 @[equational_result]
@@ -711,7 +726,8 @@ theorem Finite.Equation1526_implies_Equation1323 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq11 (X Y : G) : (Y ◇ (((Y ◇ Y) ◇ X) ◇ Y)) = X := by
+  have step10 : sK0 ≠ (sK1 ◇ (((sK1 ◇ sK1) ◇ sK0) ◇ sK1)) := mod_symm nh
+  have step12 (X Y : G) : (Y ◇ (((Y ◇ Y) ◇ X) ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (Y ◇ (s ◇ Y))) S := by
       intro
@@ -728,8 +744,8 @@ theorem Finite.Equation1526_implies_Equation1323 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (sK1 ◇ (((sK1 ◇ sK1) ◇ sK0) ◇ sK1)) := mod_symm nh
-  subsumption eq12 eq11
+  have step19 : sK0 ≠ sK0 := superpose step12 step10
+  subsumption step19 rfl
 
 
 @[equational_result]
@@ -737,7 +753,8 @@ theorem Finite.Equation1526_implies_Equation2744 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq10 (X Y : G) : (((Y ◇ Y) ◇ (Y ◇ X)) ◇ Y) = X := by
+  have step10 : sK0 ≠ (((sK1 ◇ sK1) ◇ (sK1 ◇ sK0)) ◇ sK1) := mod_symm nh
+  have step11 (X Y : G) : (((Y ◇ Y) ◇ (Y ◇ X)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -754,8 +771,8 @@ theorem Finite.Equation1526_implies_Equation2744 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (((sK1 ◇ sK1) ◇ (sK1 ◇ sK0)) ◇ sK1) := mod_symm nh
-  subsumption eq12 eq10
+  have step17 : sK0 ≠ sK0 := superpose step11 step10
+  subsumption step17 rfl
 
 
 @[equational_result]
@@ -763,8 +780,9 @@ theorem Finite.Equation1630_implies_Equation4268 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq8 (X0 X1 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ X1)) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : ((X ◇ (X ◇ Y)) ◇ (X ◇ (X ◇ Y))) = X := by
+  have step8 (X0 X1 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ X1)) = X0 := mod_symm (h ..)
+  have step9 : (sK0 ◇ (sK0 ◇ sK0)) ≠ (sK0 ◇ (sK0 ◇ sK1)) := mod_symm nh
+  have step10 (X Y : G) : ((X ◇ (X ◇ Y)) ◇ (X ◇ (X ◇ Y))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ s)) S := by
       intro
@@ -781,10 +799,9 @@ theorem Finite.Equation1630_implies_Equation4268 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : (sK0 ◇ (sK0 ◇ sK1)) ≠ (sK0 ◇ (sK0 ◇ sK0)) := mod_symm nh
-  have eq17 (X0 X1 X2 : G) : (X0 ◇ (X0 ◇ X1)) = (X0 ◇ (X0 ◇ X2)) := superpose eq9 eq8
-  have eq34 (X0 : G) : (sK0 ◇ (sK0 ◇ sK0)) ≠ (sK0 ◇ (sK0 ◇ X0)) := superpose eq17 eq10
-  subsumption eq34 eq17
+  have step17 (X0 X1 X2 : G) : (X0 ◇ (X0 ◇ X1)) = (X0 ◇ (X0 ◇ X2)) := superpose step10 step8
+  have step34 (X0 : G) : (sK0 ◇ (sK0 ◇ sK0)) ≠ (sK0 ◇ (sK0 ◇ X0)) := superpose step17 step9
+  subsumption step34 step17
 
 
 @[equational_result]
@@ -792,7 +809,8 @@ theorem Finite.Equation1648_implies_Equation206 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X Y : G) : ((X ◇ (X ◇ Y)) ◇ Y) = X := by
+  have step9 : sK0 ≠ ((sK0 ◇ (sK0 ◇ sK1)) ◇ sK1) := mod_symm nh
+  have step10 (X Y : G) : ((X ◇ (X ◇ Y)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -809,8 +827,8 @@ theorem Finite.Equation1648_implies_Equation206 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((sK0 ◇ (sK0 ◇ sK1)) ◇ sK1) := mod_symm nh
-  subsumption eq10 eq9
+  have step12 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step12 rfl
 
 
 @[equational_result]
@@ -818,7 +836,8 @@ theorem Finite.Equation1692_implies_Equation63 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X Y : G) : (Y ◇ (X ◇ (X ◇ Y))) = X := by
+  have step9 : sK0 ≠ (sK1 ◇ (sK0 ◇ (sK0 ◇ sK1))) := mod_symm nh
+  have step10 (X Y : G) : (Y ◇ (X ◇ (X ◇ Y))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (Y ◇ s)) S := by
       intro
@@ -835,8 +854,8 @@ theorem Finite.Equation1692_implies_Equation63 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ (sK1 ◇ (sK0 ◇ (sK0 ◇ sK1))) := mod_symm nh
-  subsumption eq10 eq9
+  have step13 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step13 rfl
 
 
 @[equational_result]
@@ -844,7 +863,8 @@ theorem Finite.Equation1722_implies_Equation1832 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq10 (X Y : G) : (((Y ◇ Y) ◇ (X ◇ Y)) ◇ Y) = X := by
+  have step10 : sK0 ≠ ((sK0 ◇ (sK0 ◇ sK0)) ◇ (sK0 ◇ sK0)) := mod_symm nh
+  have step11 (X Y : G) : (((Y ◇ Y) ◇ (X ◇ Y)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -861,12 +881,11 @@ theorem Finite.Equation1722_implies_Equation1832 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((sK0 ◇ (sK0 ◇ sK0)) ◇ (sK0 ◇ sK0)) := mod_symm nh
-  have eq15 (X0 X1 : G) : ((X1 ◇ X1) ◇ (X0 ◇ X1)) = (((X1 ◇ X1) ◇ X0) ◇ X1) := superpose eq10 eq10
-  have eq18 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = (((X0 ◇ X0) ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) := superpose eq10 eq15
-  have eq47 (X0 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ X0)) = X0 := superpose eq18 eq10
-  have eq74 : sK0 ≠ sK0 := superpose eq47 eq12
-  subsumption eq74 rfl
+  have step15 (X0 X1 : G) : ((X1 ◇ X1) ◇ (X0 ◇ X1)) = (((X1 ◇ X1) ◇ X0) ◇ X1) := superpose step11 step11
+  have step18 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = (((X0 ◇ X0) ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) := superpose step11 step15
+  have step47 (X0 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ X0)) = X0 := superpose step18 step11
+  have step74 : sK0 ≠ sK0 := superpose step47 step10
+  subsumption step74 rfl
 
 
 @[equational_result]
@@ -874,7 +893,8 @@ theorem Finite.Equation1722_implies_Equation2644 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq10 (X Y : G) : (((Y ◇ Y) ◇ (X ◇ Y)) ◇ Y) = X := by
+  have step10 : sK0 ≠ (((sK0 ◇ sK0) ◇ (sK0 ◇ sK0)) ◇ sK0) := mod_symm nh
+  have step11 (X Y : G) : (((Y ◇ Y) ◇ (X ◇ Y)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -891,8 +911,8 @@ theorem Finite.Equation1722_implies_Equation2644 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (((sK0 ◇ sK0) ◇ (sK0 ◇ sK0)) ◇ sK0) := mod_symm nh
-  subsumption eq12 eq10
+  have step16 : sK0 ≠ sK0 := superpose step11 step10
+  subsumption step16 rfl
 
 
 @[equational_result]
@@ -900,7 +920,8 @@ theorem Finite.Equation1722_implies_Equation2737 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq10 (X Y : G) : (((Y ◇ Y) ◇ (X ◇ Y)) ◇ Y) = X := by
+  have step10 : sK0 ≠ (((sK1 ◇ sK1) ◇ (sK0 ◇ sK1)) ◇ sK1) := mod_symm nh
+  have step11 (X Y : G) : (((Y ◇ Y) ◇ (X ◇ Y)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -917,8 +938,8 @@ theorem Finite.Equation1722_implies_Equation2737 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (((sK1 ◇ sK1) ◇ (sK0 ◇ sK1)) ◇ sK1) := mod_symm nh
-  subsumption eq12 eq10
+  have step16 : sK0 ≠ sK0 := superpose step11 step10
+  subsumption step16 rfl
 
 
 @[equational_result]
@@ -926,15 +947,16 @@ theorem Finite.Equation1722_implies_Equation3143 (G : Type*) [Magma G] [Finite G
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq11 (X Y : G) : ((((Y ◇ Y) ◇ X) ◇ Y) ◇ Y) = X := by
+  have step10 : sK0 ≠ ((((sK1 ◇ sK1) ◇ sK0) ◇ sK1) ◇ sK1) := mod_symm nh
+  have step11 (X Y : G) : (((Y ◇ Y) ◇ (X ◇ Y)) ◇ Y) = X := by
     let S : Set G := Set.univ
-    have m1 : S.MapsTo (fun s => ((s ◇ Y) ◇ Y)) S := by
+    have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
       simp [S]
-    have m2 : S.MapsTo (fun s => ((Y ◇ Y) ◇ s)) S := by
+    have m2 : S.MapsTo (fun s => ((Y ◇ Y) ◇ (s ◇ Y))) S := by
       intro
       simp [S]
-    have linv : S.LeftInvOn (fun s => ((Y ◇ Y) ◇ s)) (fun s => ((s ◇ Y) ◇ Y)) := by
+    have linv : S.LeftInvOn (fun s => ((Y ◇ Y) ◇ (s ◇ Y))) (fun s => (s ◇ Y)) := by
       intro a ha
       simp [S]
       simp [← h]
@@ -943,8 +965,9 @@ theorem Finite.Equation1722_implies_Equation3143 (G : Type*) [Magma G] [Finite G
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((((sK1 ◇ sK1) ◇ sK0) ◇ sK1) ◇ sK1) := mod_symm nh
-  subsumption eq12 eq11
+  have step15 (X0 X1 : G) : (((X1 ◇ X1) ◇ X0) ◇ X1) = ((X1 ◇ X1) ◇ (X0 ◇ X1)) := superpose step11 step11
+  have step16 : sK0 ≠ (((sK1 ◇ sK1) ◇ (sK0 ◇ sK1)) ◇ sK1) := superpose step15 step10
+  subsumption step16 step11
 
 
 @[equational_result]
@@ -952,7 +975,8 @@ theorem Finite.Equation1729_implies_Equation917 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq10 (X Y : G) : (Y ◇ ((Y ◇ Y) ◇ (X ◇ Y))) = X := by
+  have step10 : sK0 ≠ (sK1 ◇ ((sK1 ◇ sK1) ◇ (sK0 ◇ sK1))) := mod_symm nh
+  have step11 (X Y : G) : (Y ◇ ((Y ◇ Y) ◇ (X ◇ Y))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (Y ◇ s)) S := by
       intro
@@ -969,8 +993,8 @@ theorem Finite.Equation1729_implies_Equation917 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (sK1 ◇ ((sK1 ◇ sK1) ◇ (sK0 ◇ sK1))) := mod_symm nh
-  subsumption eq12 eq10
+  have step16 : sK0 ≠ sK0 := superpose step11 step10
+  subsumption step16 rfl
 
 
 @[equational_result]
@@ -978,8 +1002,9 @@ theorem Finite.Equation476_implies_Equation3862 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0)))) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ (Y ◇ X)))) = X := by
+  have step8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0)))) = X0 := mod_symm (h ..)
+  have step9 : (sK0 ◇ sK0) ≠ ((sK0 ◇ (sK0 ◇ sK0)) ◇ sK0) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ (Y ◇ X)))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ (Y ◇ s)))) S := by
       intro
@@ -996,10 +1021,9 @@ theorem Finite.Equation476_implies_Equation3862 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : (sK0 ◇ sK0) ≠ ((sK0 ◇ (sK0 ◇ sK0)) ◇ sK0) := mod_symm nh
-  have eq15 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ (X0 ◇ X0)) ◇ X0) := superpose eq8 eq9
-  have eq17 : (sK0 ◇ sK0) ≠ (sK0 ◇ sK0) := superpose eq15 eq10
-  subsumption eq17 rfl
+  have step15 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ (X0 ◇ X0)) ◇ X0) := superpose step8 step10
+  have step17 : (sK0 ◇ sK0) ≠ (sK0 ◇ sK0) := superpose step15 step9
+  subsumption step17 rfl
 
 
 @[equational_result]
@@ -1007,7 +1031,8 @@ theorem Finite.Equation477_implies_Equation1492 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ Y))) = X := by
+  have step9 : sK0 ≠ ((sK1 ◇ sK0) ◇ (sK1 ◇ (sK1 ◇ sK1))) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ Y))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ (Y ◇ Y)))) S := by
       intro
@@ -1024,8 +1049,8 @@ theorem Finite.Equation477_implies_Equation1492 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((sK1 ◇ sK0) ◇ (sK1 ◇ (sK1 ◇ sK1))) := mod_symm nh
-  subsumption eq10 eq9
+  have step13 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step13 rfl
 
 
 @[equational_result]
@@ -1033,8 +1058,9 @@ theorem Finite.Equation477_implies_Equation1519 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ (X1 ◇ X1)))) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ Y))) = X := by
+  have step8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ (X1 ◇ X1)))) = X0 := mod_symm (h ..)
+  have step9 : sK0 ≠ ((sK1 ◇ sK1) ◇ (sK0 ◇ (sK1 ◇ sK1))) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ Y))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ (Y ◇ Y)))) S := by
       intro
@@ -1051,14 +1077,13 @@ theorem Finite.Equation477_implies_Equation1519 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((sK1 ◇ sK1) ◇ (sK0 ◇ (sK1 ◇ sK1))) := mod_symm nh
-  have eq11 (X0 X1 : G) : (X1 ◇ (X1 ◇ X1)) = (X0 ◇ ((X1 ◇ X0) ◇ ((X1 ◇ X0) ◇ (X1 ◇ X0)))) := superpose eq9 eq9
-  have eq17 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ X0) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ X0))) := superpose eq9 eq11
-  have eq45 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = (((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))))) := superpose eq17 eq11
-  have eq47 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) := superpose eq9 eq45
-  have eq125 (X0 X1 : G) : ((X0 ◇ X0) ◇ (X1 ◇ (X0 ◇ X0))) = X1 := superpose eq47 eq8
-  have eq174 : sK0 ≠ sK0 := superpose eq125 eq10
-  subsumption eq174 rfl
+  have step11 (X0 X1 : G) : (X1 ◇ (X1 ◇ X1)) = (X0 ◇ ((X1 ◇ X0) ◇ ((X1 ◇ X0) ◇ (X1 ◇ X0)))) := superpose step10 step10
+  have step17 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ X0) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ X0))) := superpose step10 step11
+  have step45 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = (((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))))) := superpose step17 step11
+  have step47 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) := superpose step10 step45
+  have step125 (X0 X1 : G) : ((X0 ◇ X0) ◇ (X1 ◇ (X0 ◇ X0))) = X1 := superpose step47 step8
+  have step174 : sK0 ≠ sK0 := superpose step125 step9
+  subsumption step174 rfl
 
 
 @[equational_result]
@@ -1066,8 +1091,9 @@ theorem Finite.Equation477_implies_Equation3150 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ (X1 ◇ X1)))) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ Y))) = X := by
+  have step8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ (X1 ◇ X1)))) = X0 := mod_symm (h ..)
+  have step9 : sK0 ≠ ((((sK1 ◇ sK1) ◇ sK1) ◇ sK0) ◇ sK1) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ Y))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ (Y ◇ Y)))) S := by
       intro
@@ -1084,20 +1110,19 @@ theorem Finite.Equation477_implies_Equation3150 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((((sK1 ◇ sK1) ◇ sK1) ◇ sK0) ◇ sK1) := mod_symm nh
-  have eq11 (X0 X1 : G) : (X1 ◇ (X1 ◇ X1)) = (X0 ◇ ((X1 ◇ X0) ◇ ((X1 ◇ X0) ◇ (X1 ◇ X0)))) := superpose eq9 eq9
-  have eq15 (X0 X1 : G) : ((X1 ◇ X0) ◇ ((X1 ◇ X0) ◇ (X1 ◇ X0))) = ((X1 ◇ (X1 ◇ X1)) ◇ (X0 ◇ (X0 ◇ X0))) := superpose eq9 eq11
-  have eq17 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ X0) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ X0))) := superpose eq9 eq11
-  have eq45 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = (((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))))) := superpose eq17 eq11
-  have eq47 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) := superpose eq9 eq45
-  have eq67 (X0 X1 X2 : G) : ((X0 ◇ X1) ◇ (X2 ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X1 ◇ (X1 ◇ X1))))) = X2 := superpose eq15 eq8
-  have eq126 (X0 X1 : G) : (((X0 ◇ X0) ◇ X1) ◇ (X0 ◇ X0)) = X1 := superpose eq47 eq9
-  have eq265 (X0 X1 X2 : G) : (((X0 ◇ X0) ◇ X1) ◇ (X2 ◇ ((X0 ◇ X0) ◇ (X1 ◇ (X1 ◇ X1))))) = X2 := superpose eq47 eq67
-  have eq773 (X0 X1 : G) : (((X0 ◇ X0) ◇ X0) ◇ (X1 ◇ X0)) = X1 := superpose eq9 eq265
-  have eq941 (X0 X1 : G) : ((((X0 ◇ X0) ◇ X0) ◇ X1) ◇ (((X0 ◇ X0) ◇ X0) ◇ (X0 ◇ X0))) = X1 := superpose eq773 eq9
-  have eq1009 (X0 X1 : G) : ((((X0 ◇ X0) ◇ X0) ◇ X1) ◇ X0) = X1 := superpose eq126 eq941
-  have eq1176 : sK0 ≠ sK0 := superpose eq1009 eq10
-  subsumption eq1176 rfl
+  have step11 (X0 X1 : G) : (X1 ◇ (X1 ◇ X1)) = (X0 ◇ ((X1 ◇ X0) ◇ ((X1 ◇ X0) ◇ (X1 ◇ X0)))) := superpose step10 step10
+  have step15 (X0 X1 : G) : ((X1 ◇ X0) ◇ ((X1 ◇ X0) ◇ (X1 ◇ X0))) = ((X1 ◇ (X1 ◇ X1)) ◇ (X0 ◇ (X0 ◇ X0))) := superpose step10 step11
+  have step17 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ X0) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ X0))) := superpose step10 step11
+  have step45 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = (((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))))) := superpose step17 step11
+  have step47 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) := superpose step10 step45
+  have step67 (X0 X1 X2 : G) : ((X0 ◇ X1) ◇ (X2 ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X1 ◇ (X1 ◇ X1))))) = X2 := superpose step15 step8
+  have step126 (X0 X1 : G) : (((X0 ◇ X0) ◇ X1) ◇ (X0 ◇ X0)) = X1 := superpose step47 step10
+  have step265 (X0 X1 X2 : G) : (((X0 ◇ X0) ◇ X1) ◇ (X2 ◇ ((X0 ◇ X0) ◇ (X1 ◇ (X1 ◇ X1))))) = X2 := superpose step47 step67
+  have step773 (X0 X1 : G) : (((X0 ◇ X0) ◇ X0) ◇ (X1 ◇ X0)) = X1 := superpose step10 step265
+  have step941 (X0 X1 : G) : ((((X0 ◇ X0) ◇ X0) ◇ X1) ◇ (((X0 ◇ X0) ◇ X0) ◇ (X0 ◇ X0))) = X1 := superpose step773 step10
+  have step1009 (X0 X1 : G) : ((((X0 ◇ X0) ◇ X0) ◇ X1) ◇ X0) = X1 := superpose step126 step941
+  have step1176 : sK0 ≠ sK0 := superpose step1009 step9
+  subsumption step1176 rfl
 
 
 @[equational_result]
@@ -1105,7 +1130,9 @@ theorem Finite.Equation481_implies_Equation1488 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X Y Z : G) : ((Y ◇ X) ◇ (Y ◇ (Z ◇ Z))) = X := by
+  have step8 (X0 X1 X2 : G) : (X1 ◇ (X0 ◇ (X1 ◇ (X2 ◇ X2)))) = X0 := mod_symm (h ..)
+  have step9 : sK0 ≠ ((sK1 ◇ sK0) ◇ (sK1 ◇ (sK0 ◇ sK0))) := mod_symm nh
+  have step10 (X Y Z : G) : ((Y ◇ X) ◇ (Y ◇ (Z ◇ Z))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ (Z ◇ Z)))) S := by
       intro
@@ -1122,8 +1149,9 @@ theorem Finite.Equation481_implies_Equation1488 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((sK1 ◇ sK0) ◇ (sK1 ◇ (sK0 ◇ sK0))) := mod_symm nh
-  subsumption eq10 eq9
+  have step12 (X0 X1 : G) : (X0 ◇ X0) = (X1 ◇ X1) := superpose step8 step8
+  have step17 (X0 : G) : sK0 ≠ ((sK1 ◇ sK0) ◇ (sK1 ◇ (X0 ◇ X0))) := superpose step12 step9
+  subsumption step17 step10
 
 
 @[equational_result]
@@ -1131,7 +1159,9 @@ theorem Finite.Equation481_implies_Equation1496 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, sK2, nh⟩ := nh
-  have eq9 (X Y Z : G) : ((Y ◇ X) ◇ (Y ◇ (Z ◇ Z))) = X := by
+  have step8 (X0 X1 X2 : G) : (X1 ◇ (X0 ◇ (X1 ◇ (X2 ◇ X2)))) = X0 := mod_symm (h ..)
+  have step9 : sK0 ≠ ((sK1 ◇ sK0) ◇ (sK1 ◇ (sK2 ◇ sK2))) := mod_symm nh
+  have step10 (X Y Z : G) : ((Y ◇ X) ◇ (Y ◇ (Z ◇ Z))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ (Z ◇ Z)))) S := by
       intro
@@ -1148,8 +1178,9 @@ theorem Finite.Equation481_implies_Equation1496 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((sK1 ◇ sK0) ◇ (sK1 ◇ (sK2 ◇ sK2))) := mod_symm nh
-  subsumption eq10 eq9
+  have step12 (X0 X1 : G) : (X1 ◇ X1) = (X0 ◇ X0) := superpose step8 step8
+  have step20 (X0 : G) : sK0 ≠ ((sK1 ◇ sK0) ◇ (sK1 ◇ (X0 ◇ X0))) := superpose step12 step9
+  subsumption step20 step10
 
 
 @[equational_result]
@@ -1157,8 +1188,9 @@ theorem Finite.Equation481_implies_Equation2041 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq8 (X0 X1 X2 : G) : (X1 ◇ (X0 ◇ (X1 ◇ (X2 ◇ X2)))) = X0 := mod_symm (h ..)
-  have eq9 (X Y Z : G) : ((Y ◇ X) ◇ (Y ◇ (Z ◇ Z))) = X := by
+  have step8 (X0 X1 X2 : G) : (X1 ◇ (X0 ◇ (X1 ◇ (X2 ◇ X2)))) = X0 := mod_symm (h ..)
+  have step9 : sK0 ≠ (((sK0 ◇ sK0) ◇ sK1) ◇ (sK0 ◇ sK1)) := mod_symm nh
+  have step10 (X Y Z : G) : ((Y ◇ X) ◇ (Y ◇ (Z ◇ Z))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ (Z ◇ Z)))) S := by
       intro
@@ -1175,10 +1207,9 @@ theorem Finite.Equation481_implies_Equation2041 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ (((sK0 ◇ sK0) ◇ sK1) ◇ (sK0 ◇ sK1)) := mod_symm nh
-  have eq38 (X0 X1 X2 : G) : (((X1 ◇ X1) ◇ X0) ◇ (X2 ◇ X0)) = X2 := superpose eq9 eq8
-  have eq78 : sK0 ≠ sK0 := superpose eq38 eq10
-  subsumption eq78 rfl
+  have step38 (X0 X1 X2 : G) : (((X1 ◇ X1) ◇ X0) ◇ (X2 ◇ X0)) = X2 := superpose step10 step8
+  have step78 : sK0 ≠ sK0 := superpose step38 step9
+  subsumption step78 rfl
 
 
 @[equational_result]
@@ -1186,7 +1217,8 @@ theorem Finite.Equation481_implies_Equation3161 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, sK2, nh⟩ := nh
-  have eq9 (X Y Z : G) : ((Y ◇ X) ◇ (Y ◇ (Z ◇ Z))) = X := by
+  have step9 : sK0 ≠ ((((sK1 ◇ sK1) ◇ sK2) ◇ sK0) ◇ sK2) := mod_symm nh
+  have step10 (X Y Z : G) : ((Y ◇ X) ◇ (Y ◇ (Z ◇ Z))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ (Z ◇ Z)))) S := by
       intro
@@ -1203,10 +1235,9 @@ theorem Finite.Equation481_implies_Equation3161 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((((sK1 ◇ sK1) ◇ sK2) ◇ sK0) ◇ sK2) := mod_symm nh
-  have eq35 (X0 X1 X2 : G) : ((((X1 ◇ X1) ◇ X0) ◇ X2) ◇ X0) = X2 := superpose eq9 eq9
-  have eq55 : sK0 ≠ sK0 := superpose eq35 eq10
-  subsumption eq55 rfl
+  have step35 (X0 X1 X2 : G) : ((((X1 ◇ X1) ◇ X0) ◇ X2) ◇ X0) = X2 := superpose step10 step10
+  have step55 : sK0 ≠ sK0 := superpose step35 step9
+  subsumption step55 rfl
 
 
 @[equational_result]
@@ -1214,8 +1245,9 @@ theorem Finite.Equation504_implies_Equation1629 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq9 (X0 X1 : G) : (X1 ◇ (X1 ◇ (X0 ◇ (X1 ◇ X1)))) = X0 := mod_symm (h ..)
-  have eq10 (X Y : G) : ((Y ◇ (Y ◇ X)) ◇ (Y ◇ Y)) = X := by
+  have step9 (X0 X1 : G) : (X1 ◇ (X1 ◇ (X0 ◇ (X1 ◇ X1)))) = X0 := mod_symm (h ..)
+  have step10 : sK0 ≠ ((sK0 ◇ sK0) ◇ ((sK0 ◇ sK0) ◇ sK0)) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (Y ◇ X)) ◇ (Y ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ Y))) S := by
       intro
@@ -1232,12 +1264,11 @@ theorem Finite.Equation504_implies_Equation1629 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((sK0 ◇ sK0) ◇ ((sK0 ◇ sK0) ◇ sK0)) := mod_symm nh
-  have eq13 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ X1))) = ((X1 ◇ X0) ◇ (X1 ◇ X1)) := superpose eq9 eq10
-  have eq24 (X0 X1 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X1 ◇ (X0 ◇ (X0 ◇ (X0 ◇ X0)))))) = X1 := superpose eq13 eq9
-  have eq53 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ X0)) = X0 := superpose eq9 eq24
-  have eq102 : sK0 ≠ sK0 := superpose eq53 eq12
-  subsumption eq102 rfl
+  have step13 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ X1))) = ((X1 ◇ X0) ◇ (X1 ◇ X1)) := superpose step9 step11
+  have step24 (X0 X1 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X1 ◇ (X0 ◇ (X0 ◇ (X0 ◇ X0)))))) = X1 := superpose step13 step9
+  have step53 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ X0)) = X0 := superpose step9 step24
+  have step102 : sK0 ≠ sK0 := superpose step53 step10
+  subsumption step102 rfl
 
 
 @[equational_result]
@@ -1245,7 +1276,8 @@ theorem Finite.Equation504_implies_Equation1925 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq10 (X Y : G) : ((Y ◇ (Y ◇ X)) ◇ (Y ◇ Y)) = X := by
+  have step10 : sK0 ≠ ((sK1 ◇ (sK1 ◇ sK0)) ◇ (sK1 ◇ sK1)) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (Y ◇ X)) ◇ (Y ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ Y))) S := by
       intro
@@ -1262,8 +1294,8 @@ theorem Finite.Equation504_implies_Equation1925 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((sK1 ◇ (sK1 ◇ sK0)) ◇ (sK1 ◇ sK1)) := mod_symm nh
-  subsumption eq12 eq10
+  have step15 : sK0 ≠ sK0 := superpose step11 step10
+  subsumption step15 rfl
 
 
 @[equational_result]
@@ -1271,15 +1303,17 @@ theorem Finite.Equation504_implies_Equation817 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq11 (X Y : G) : (Y ◇ ((Y ◇ X) ◇ (Y ◇ Y))) = X := by
+  have step9 (X0 X1 : G) : (X1 ◇ (X1 ◇ (X0 ◇ (X1 ◇ X1)))) = X0 := mod_symm (h ..)
+  have step10 : sK0 ≠ (sK0 ◇ ((sK0 ◇ sK0) ◇ (sK0 ◇ sK0))) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (Y ◇ X)) ◇ (Y ◇ Y)) = X := by
     let S : Set G := Set.univ
-    have m1 : S.MapsTo (fun s => (Y ◇ (s ◇ (Y ◇ Y)))) S := by
+    have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ Y))) S := by
       intro
       simp [S]
-    have m2 : S.MapsTo (fun s => (Y ◇ s)) S := by
+    have m2 : S.MapsTo (fun s => (Y ◇ (Y ◇ s))) S := by
       intro
       simp [S]
-    have linv : S.LeftInvOn (fun s => (Y ◇ s)) (fun s => (Y ◇ (s ◇ (Y ◇ Y)))) := by
+    have linv : S.LeftInvOn (fun s => (Y ◇ (Y ◇ s))) (fun s => (s ◇ (Y ◇ Y))) := by
       intro a ha
       simp [S]
       simp [← h]
@@ -1288,8 +1322,9 @@ theorem Finite.Equation504_implies_Equation817 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (sK0 ◇ ((sK0 ◇ sK0) ◇ (sK0 ◇ sK0))) := mod_symm nh
-  subsumption eq12 eq11
+  have step13 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ X1))) = ((X1 ◇ X0) ◇ (X1 ◇ X1)) := superpose step9 step11
+  have step15 : sK0 ≠ (sK0 ◇ (sK0 ◇ (sK0 ◇ (sK0 ◇ sK0)))) := superpose step13 step10
+  subsumption step15 step9
 
 
 @[equational_result]
@@ -1297,15 +1332,17 @@ theorem Finite.Equation504_implies_Equation910 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq11 (X Y : G) : (Y ◇ ((Y ◇ X) ◇ (Y ◇ Y))) = X := by
+  have step9 (X0 X1 : G) : (X1 ◇ (X1 ◇ (X0 ◇ (X1 ◇ X1)))) = X0 := mod_symm (h ..)
+  have step10 : sK0 ≠ (sK1 ◇ ((sK1 ◇ sK0) ◇ (sK1 ◇ sK1))) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (Y ◇ X)) ◇ (Y ◇ Y)) = X := by
     let S : Set G := Set.univ
-    have m1 : S.MapsTo (fun s => (Y ◇ (s ◇ (Y ◇ Y)))) S := by
+    have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ Y))) S := by
       intro
       simp [S]
-    have m2 : S.MapsTo (fun s => (Y ◇ s)) S := by
+    have m2 : S.MapsTo (fun s => (Y ◇ (Y ◇ s))) S := by
       intro
       simp [S]
-    have linv : S.LeftInvOn (fun s => (Y ◇ s)) (fun s => (Y ◇ (s ◇ (Y ◇ Y)))) := by
+    have linv : S.LeftInvOn (fun s => (Y ◇ (Y ◇ s))) (fun s => (s ◇ (Y ◇ Y))) := by
       intro a ha
       simp [S]
       simp [← h]
@@ -1314,8 +1351,9 @@ theorem Finite.Equation504_implies_Equation910 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (sK1 ◇ ((sK1 ◇ sK0) ◇ (sK1 ◇ sK1))) := mod_symm nh
-  subsumption eq12 eq11
+  have step13 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ X1))) = ((X1 ◇ X0) ◇ (X1 ◇ X1)) := superpose step9 step11
+  have step15 : sK0 ≠ (sK1 ◇ (sK1 ◇ (sK0 ◇ (sK1 ◇ sK1)))) := superpose step13 step10
+  subsumption step15 step9
 
 
 @[equational_result]
@@ -1323,7 +1361,8 @@ theorem Finite.Equation511_implies_Equation2338 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq11 (X Y : G) : ((Y ◇ (Y ◇ (Y ◇ X))) ◇ Y) = X := by
+  have step11 : sK0 ≠ ((sK1 ◇ (sK1 ◇ (sK1 ◇ sK0))) ◇ sK1) := mod_symm nh
+  have step12 (X Y : G) : ((Y ◇ (Y ◇ (Y ◇ X))) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -1340,8 +1379,8 @@ theorem Finite.Equation511_implies_Equation2338 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : sK0 ≠ ((sK1 ◇ (sK1 ◇ (sK1 ◇ sK0))) ◇ sK1) := mod_symm nh
-  subsumption eq14 eq11
+  have step19 : sK0 ≠ sK0 := superpose step12 step11
+  subsumption step19 rfl
 
 
 @[equational_result]
@@ -1349,8 +1388,9 @@ theorem Finite.Equation511_implies_Equation4435 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq10 (X0 X1 : G) : (X1 ◇ (X1 ◇ (X1 ◇ (X0 ◇ X1)))) = X0 := mod_symm (h ..)
-  have eq11 (X Y : G) : ((Y ◇ (Y ◇ (Y ◇ X))) ◇ Y) = X := by
+  have step10 (X0 X1 : G) : (X1 ◇ (X1 ◇ (X1 ◇ (X0 ◇ X1)))) = X0 := mod_symm (h ..)
+  have step11 : (sK0 ◇ (sK1 ◇ sK0)) ≠ ((sK0 ◇ sK1) ◇ sK0) := mod_symm nh
+  have step12 (X Y : G) : ((Y ◇ (Y ◇ (Y ◇ X))) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -1367,10 +1407,9 @@ theorem Finite.Equation511_implies_Equation4435 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : (sK0 ◇ (sK1 ◇ sK0)) ≠ ((sK0 ◇ sK1) ◇ sK0) := mod_symm nh
-  have eq18 (X0 X1 : G) : (X1 ◇ (X0 ◇ X1)) = ((X1 ◇ X0) ◇ X1) := superpose eq10 eq11
-  have eq25 : (sK0 ◇ (sK1 ◇ sK0)) ≠ (sK0 ◇ (sK1 ◇ sK0)) := superpose eq18 eq14
-  subsumption eq25 rfl
+  have step18 (X0 X1 : G) : (X1 ◇ (X0 ◇ X1)) = ((X1 ◇ X0) ◇ X1) := superpose step10 step12
+  have step25 : (sK0 ◇ (sK1 ◇ sK0)) ≠ (sK0 ◇ (sK1 ◇ sK0)) := superpose step18 step11
+  subsumption step25 rfl
 
 
 @[equational_result]
@@ -1378,15 +1417,17 @@ theorem Finite.Equation511_implies_Equation714 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq13 (X Y : G) : (Y ◇ (Y ◇ ((Y ◇ X) ◇ Y))) = X := by
+  have step10 (X0 X1 : G) : (X1 ◇ (X1 ◇ (X1 ◇ (X0 ◇ X1)))) = X0 := mod_symm (h ..)
+  have step11 : sK0 ≠ (sK1 ◇ (sK1 ◇ ((sK1 ◇ sK0) ◇ sK1))) := mod_symm nh
+  have step12 (X Y : G) : ((Y ◇ (Y ◇ (Y ◇ X))) ◇ Y) = X := by
     let S : Set G := Set.univ
-    have m1 : S.MapsTo (fun s => (Y ◇ (Y ◇ (s ◇ Y)))) S := by
+    have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
       simp [S]
-    have m2 : S.MapsTo (fun s => (Y ◇ s)) S := by
+    have m2 : S.MapsTo (fun s => (Y ◇ (Y ◇ (Y ◇ s)))) S := by
       intro
       simp [S]
-    have linv : S.LeftInvOn (fun s => (Y ◇ s)) (fun s => (Y ◇ (Y ◇ (s ◇ Y)))) := by
+    have linv : S.LeftInvOn (fun s => (Y ◇ (Y ◇ (Y ◇ s)))) (fun s => (s ◇ Y)) := by
       intro a ha
       simp [S]
       simp [← h]
@@ -1395,8 +1436,9 @@ theorem Finite.Equation511_implies_Equation714 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : sK0 ≠ (sK1 ◇ (sK1 ◇ ((sK1 ◇ sK0) ◇ sK1))) := mod_symm nh
-  subsumption eq14 eq13
+  have step18 (X0 X1 : G) : (X1 ◇ (X0 ◇ X1)) = ((X1 ◇ X0) ◇ X1) := superpose step10 step12
+  have step21 : sK0 ≠ (sK1 ◇ (sK1 ◇ (sK1 ◇ (sK0 ◇ sK1)))) := superpose step18 step11
+  subsumption step21 step10
 
 
 @[equational_result]
@@ -1404,7 +1446,8 @@ theorem Finite.Equation63_implies_Equation1692 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ ((Y ◇ X) ◇ Y)) = X := by
+  have step9 : sK0 ≠ ((sK1 ◇ sK0) ◇ ((sK1 ◇ sK0) ◇ sK1)) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ ((Y ◇ X) ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (s ◇ Y))) S := by
       intro
@@ -1421,8 +1464,8 @@ theorem Finite.Equation63_implies_Equation1692 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((sK1 ◇ sK0) ◇ ((sK1 ◇ sK0) ◇ sK1)) := mod_symm nh
-  subsumption eq10 eq9
+  have step17 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step17 rfl
 
 
 @[equational_result]
@@ -1430,7 +1473,8 @@ theorem Finite.Equation65_implies_Equation1426 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ X))) = X := by
+  have step9 : sK0 ≠ ((sK0 ◇ sK0) ◇ (sK0 ◇ (sK0 ◇ sK0))) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ s))) S := by
       intro
@@ -1447,8 +1491,8 @@ theorem Finite.Equation65_implies_Equation1426 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((sK0 ◇ sK0) ◇ (sK0 ◇ (sK0 ◇ sK0))) := mod_symm nh
-  subsumption eq10 eq9
+  have step14 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step14 rfl
 
 
 @[equational_result]
@@ -1456,7 +1500,8 @@ theorem Finite.Equation65_implies_Equation1491 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ X))) = X := by
+  have step9 : sK0 ≠ ((sK1 ◇ sK0) ◇ (sK1 ◇ (sK1 ◇ sK0))) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ s))) S := by
       intro
@@ -1473,8 +1518,8 @@ theorem Finite.Equation65_implies_Equation1491 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((sK1 ◇ sK0) ◇ (sK1 ◇ (sK1 ◇ sK0))) := mod_symm nh
-  subsumption eq10 eq9
+  have step14 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step14 rfl
 
 
 @[equational_result]
@@ -1482,8 +1527,9 @@ theorem Finite.Equation65_implies_Equation359 (G : Type*) [Magma G] [Finite G] (
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ X0))) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ X))) = X := by
+  have step8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ X0))) = X0 := mod_symm (h ..)
+  have step9 : (sK0 ◇ sK0) ≠ ((sK0 ◇ sK0) ◇ sK0) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ s))) S := by
       intro
@@ -1500,15 +1546,14 @@ theorem Finite.Equation65_implies_Equation359 (G : Type*) [Magma G] [Finite G] (
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : (sK0 ◇ sK0) ≠ ((sK0 ◇ sK0) ◇ sK0) := mod_symm nh
-  have eq13 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ (X0 ◇ X0)) ◇ X0) := superpose eq8 eq9
-  have eq16 (X0 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) = X0 := superpose eq13 eq8
-  have eq47 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = (((X0 ◇ (X0 ◇ X0)) ◇ X0) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ X0)) := superpose eq16 eq16
-  have eq53 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ X0) ◇ (X0 ◇ X0)) := superpose eq13 eq47
-  have eq86 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ (X0 ◇ X0)))) := superpose eq53 eq8
-  have eq93 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ X0) := superpose eq9 eq86
-  have eq118 : (sK0 ◇ sK0) ≠ (sK0 ◇ sK0) := superpose eq93 eq10
-  subsumption eq118 rfl
+  have step13 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ (X0 ◇ X0)) ◇ X0) := superpose step8 step10
+  have step16 (X0 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) = X0 := superpose step13 step8
+  have step47 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = (((X0 ◇ (X0 ◇ X0)) ◇ X0) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ X0)) := superpose step16 step16
+  have step53 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ X0) ◇ (X0 ◇ X0)) := superpose step13 step47
+  have step86 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ (X0 ◇ X0)))) := superpose step53 step8
+  have step93 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ X0) := superpose step10 step86
+  have step118 : (sK0 ◇ sK0) ≠ (sK0 ◇ sK0) := superpose step93 step9
+  subsumption step118 rfl
 
 
 @[equational_result]
@@ -1516,8 +1561,9 @@ theorem Finite.Equation65_implies_Equation3862 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ X0))) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ X))) = X := by
+  have step8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ X0))) = X0 := mod_symm (h ..)
+  have step9 : (sK0 ◇ sK0) ≠ ((sK0 ◇ (sK0 ◇ sK0)) ◇ sK0) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ s))) S := by
       intro
@@ -1534,10 +1580,9 @@ theorem Finite.Equation65_implies_Equation3862 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : (sK0 ◇ sK0) ≠ ((sK0 ◇ (sK0 ◇ sK0)) ◇ sK0) := mod_symm nh
-  have eq13 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ (X0 ◇ X0)) ◇ X0) := superpose eq8 eq9
-  have eq15 : (sK0 ◇ sK0) ≠ (sK0 ◇ sK0) := superpose eq13 eq10
-  subsumption eq15 rfl
+  have step13 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ (X0 ◇ X0)) ◇ X0) := superpose step8 step10
+  have step15 : (sK0 ◇ sK0) ≠ (sK0 ◇ sK0) := superpose step13 step9
+  subsumption step15 rfl
 
 
 @[equational_result]
@@ -1545,8 +1590,9 @@ theorem Finite.Equation65_implies_Equation614 (G : Type*) [Magma G] [Finite G] (
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ X0))) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ X))) = X := by
+  have step8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ X0))) = X0 := mod_symm (h ..)
+  have step9 : sK0 ≠ (sK0 ◇ (sK0 ◇ ((sK0 ◇ sK0) ◇ sK0))) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ s))) S := by
       intro
@@ -1563,10 +1609,9 @@ theorem Finite.Equation65_implies_Equation614 (G : Type*) [Magma G] [Finite G] (
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ (sK0 ◇ (sK0 ◇ ((sK0 ◇ sK0) ◇ sK0))) := mod_symm nh
-  have eq12 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = (X0 ◇ ((X1 ◇ X0) ◇ X0)) := superpose eq9 eq9
-  have eq15 : sK0 ≠ (sK0 ◇ (sK0 ◇ (sK0 ◇ sK0))) := superpose eq12 eq10
-  subsumption eq15 eq8
+  have step12 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = (X0 ◇ ((X1 ◇ X0) ◇ X0)) := superpose step10 step10
+  have step15 : sK0 ≠ (sK0 ◇ (sK0 ◇ (sK0 ◇ sK0))) := superpose step12 step9
+  subsumption step15 step8
 
 
 @[equational_result]
@@ -1574,8 +1619,9 @@ theorem Finite.Equation65_implies_Equation817 (G : Type*) [Magma G] [Finite G] (
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ X0))) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ X))) = X := by
+  have step8 (X0 X1 : G) : (X1 ◇ (X0 ◇ (X1 ◇ X0))) = X0 := mod_symm (h ..)
+  have step9 : sK0 ≠ (sK0 ◇ ((sK0 ◇ sK0) ◇ (sK0 ◇ sK0))) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ (Y ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ (Y ◇ s))) S := by
       intro
@@ -1592,13 +1638,12 @@ theorem Finite.Equation65_implies_Equation817 (G : Type*) [Magma G] [Finite G] (
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ (sK0 ◇ ((sK0 ◇ sK0) ◇ (sK0 ◇ sK0))) := mod_symm nh
-  have eq13 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ (X0 ◇ X0)) ◇ X0) := superpose eq8 eq9
-  have eq16 (X0 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) = X0 := superpose eq13 eq8
-  have eq47 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = (((X0 ◇ (X0 ◇ X0)) ◇ X0) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ X0)) := superpose eq16 eq16
-  have eq53 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ X0)) = (X0 ◇ (X0 ◇ X0)) := superpose eq13 eq47
-  have eq54 : sK0 ≠ (sK0 ◇ (sK0 ◇ (sK0 ◇ sK0))) := superpose eq53 eq10
-  subsumption eq54 eq8
+  have step13 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ (X0 ◇ X0)) ◇ X0) := superpose step8 step10
+  have step16 (X0 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) = X0 := superpose step13 step8
+  have step47 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = (((X0 ◇ (X0 ◇ X0)) ◇ X0) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ X0)) := superpose step16 step16
+  have step53 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ X0)) = (X0 ◇ (X0 ◇ X0)) := superpose step13 step47
+  have step54 : sK0 ≠ (sK0 ◇ (sK0 ◇ (sK0 ◇ sK0))) := superpose step53 step9
+  subsumption step54 step8
 
 
 @[equational_result]
@@ -1606,7 +1651,8 @@ theorem Finite.Equation680_implies_Equation1629 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ ((Y ◇ Y) ◇ Y)) = X := by
+  have step9 : sK0 ≠ ((sK0 ◇ sK0) ◇ ((sK0 ◇ sK0) ◇ sK0)) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ ((Y ◇ Y) ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ ((Y ◇ Y) ◇ Y))) S := by
       intro
@@ -1623,8 +1669,8 @@ theorem Finite.Equation680_implies_Equation1629 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((sK0 ◇ sK0) ◇ ((sK0 ◇ sK0) ◇ sK0)) := mod_symm nh
-  subsumption eq10 eq9
+  have step13 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step13 rfl
 
 
 @[equational_result]
@@ -1632,7 +1678,8 @@ theorem Finite.Equation680_implies_Equation1695 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ ((Y ◇ Y) ◇ Y)) = X := by
+  have step9 : sK0 ≠ ((sK1 ◇ sK0) ◇ ((sK1 ◇ sK1) ◇ sK1)) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ ((Y ◇ Y) ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ ((Y ◇ Y) ◇ Y))) S := by
       intro
@@ -1649,8 +1696,8 @@ theorem Finite.Equation680_implies_Equation1695 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((sK1 ◇ sK0) ◇ ((sK1 ◇ sK1) ◇ sK1)) := mod_symm nh
-  subsumption eq10 eq9
+  have step13 : sK0 ≠ sK0 := superpose step10 step9
+  subsumption step13 rfl
 
 
 @[equational_result]
@@ -1658,8 +1705,9 @@ theorem Finite.Equation680_implies_Equation1832 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq8 (X0 X1 : G) : (X1 ◇ (X0 ◇ ((X1 ◇ X1) ◇ X1))) = X0 := mod_symm (h ..)
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ ((Y ◇ Y) ◇ Y)) = X := by
+  have step8 (X0 X1 : G) : (X1 ◇ (X0 ◇ ((X1 ◇ X1) ◇ X1))) = X0 := mod_symm (h ..)
+  have step9 : sK0 ≠ ((sK0 ◇ (sK0 ◇ sK0)) ◇ (sK0 ◇ sK0)) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ ((Y ◇ Y) ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ ((Y ◇ Y) ◇ Y))) S := by
       intro
@@ -1676,13 +1724,12 @@ theorem Finite.Equation680_implies_Equation1832 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ ((sK0 ◇ (sK0 ◇ sK0)) ◇ (sK0 ◇ sK0)) := mod_symm nh
-  have eq12 (X0 X1 : G) : ((X1 ◇ X1) ◇ X1) = (X0 ◇ (((X1 ◇ X0) ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0))) := superpose eq9 eq9
-  have eq16 (X0 X1 : G) : (((X1 ◇ X0) ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0)) = (((X1 ◇ X1) ◇ X1) ◇ ((X0 ◇ X0) ◇ X0)) := superpose eq9 eq12
-  have eq32 (X0 X1 X2 : G) : ((X0 ◇ X1) ◇ (X2 ◇ (((X0 ◇ X0) ◇ X0) ◇ ((X1 ◇ X1) ◇ X1)))) = X2 := superpose eq16 eq8
-  have eq132 (X0 X1 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ (X1 ◇ X0)) = X1 := superpose eq9 eq32
-  have eq190 : sK0 ≠ sK0 := superpose eq132 eq10
-  subsumption eq190 rfl
+  have step12 (X0 X1 : G) : ((X1 ◇ X1) ◇ X1) = (X0 ◇ (((X1 ◇ X0) ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0))) := superpose step10 step10
+  have step16 (X0 X1 : G) : (((X1 ◇ X0) ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0)) = (((X1 ◇ X1) ◇ X1) ◇ ((X0 ◇ X0) ◇ X0)) := superpose step10 step12
+  have step32 (X0 X1 X2 : G) : ((X0 ◇ X1) ◇ (X2 ◇ (((X0 ◇ X0) ◇ X0) ◇ ((X1 ◇ X1) ◇ X1)))) = X2 := superpose step16 step8
+  have step132 (X0 X1 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ (X1 ◇ X0)) = X1 := superpose step10 step32
+  have step190 : sK0 ≠ sK0 := superpose step132 step9
+  subsumption step190 rfl
 
 
 @[equational_result]
@@ -1690,7 +1737,8 @@ theorem Finite.Equation680_implies_Equation2947 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X Y : G) : ((Y ◇ X) ◇ ((Y ◇ Y) ◇ Y)) = X := by
+  have step9 : sK0 ≠ (((sK1 ◇ (sK1 ◇ sK1)) ◇ sK0) ◇ sK1) := mod_symm nh
+  have step10 (X Y : G) : ((Y ◇ X) ◇ ((Y ◇ Y) ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ ((Y ◇ Y) ◇ Y))) S := by
       intro
@@ -1707,13 +1755,12 @@ theorem Finite.Equation680_implies_Equation2947 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq10 : sK0 ≠ (((sK1 ◇ (sK1 ◇ sK1)) ◇ sK0) ◇ sK1) := mod_symm nh
-  have eq12 (X0 X1 : G) : ((X1 ◇ X1) ◇ X1) = (X0 ◇ (((X1 ◇ X0) ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0))) := superpose eq9 eq9
-  have eq16 (X0 X1 : G) : (((X1 ◇ X0) ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0)) = (((X1 ◇ X1) ◇ X1) ◇ ((X0 ◇ X0) ◇ X0)) := superpose eq9 eq12
-  have eq31 (X0 X1 X2 : G) : (((X0 ◇ X1) ◇ X2) ◇ (((X0 ◇ X0) ◇ X0) ◇ ((X1 ◇ X1) ◇ X1))) = X2 := superpose eq16 eq9
-  have eq57 (X0 X1 : G) : (((X0 ◇ (X0 ◇ X0)) ◇ X1) ◇ X0) = X1 := superpose eq9 eq31
-  have eq106 : sK0 ≠ sK0 := superpose eq57 eq10
-  subsumption eq106 rfl
+  have step12 (X0 X1 : G) : ((X1 ◇ X1) ◇ X1) = (X0 ◇ (((X1 ◇ X0) ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0))) := superpose step10 step10
+  have step16 (X0 X1 : G) : (((X1 ◇ X0) ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0)) = (((X1 ◇ X1) ◇ X1) ◇ ((X0 ◇ X0) ◇ X0)) := superpose step10 step12
+  have step31 (X0 X1 X2 : G) : (((X0 ◇ X1) ◇ X2) ◇ (((X0 ◇ X0) ◇ X0) ◇ ((X1 ◇ X1) ◇ X1))) = X2 := superpose step16 step10
+  have step57 (X0 X1 : G) : (((X0 ◇ (X0 ◇ X0)) ◇ X1) ◇ X0) = X1 := superpose step10 step31
+  have step106 : sK0 ≠ sK0 := superpose step57 step9
+  subsumption step106 rfl
 
 
 @[equational_result]
@@ -1721,7 +1768,8 @@ theorem Finite.Equation707_implies_Equation1223 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq13 (X Y : G) : (Y ◇ (((Y ◇ X) ◇ Y) ◇ Y)) = X := by
+  have step11 : sK0 ≠ (sK0 ◇ (((sK0 ◇ sK0) ◇ sK0) ◇ sK0)) := mod_symm nh
+  have step14 (X Y : G) : (Y ◇ (((Y ◇ X) ◇ Y) ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (Y ◇ ((s ◇ Y) ◇ Y))) S := by
       intro
@@ -1738,8 +1786,8 @@ theorem Finite.Equation707_implies_Equation1223 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : sK0 ≠ (sK0 ◇ (((sK0 ◇ sK0) ◇ sK0) ◇ sK0)) := mod_symm nh
-  subsumption eq14 eq13
+  have step21 : sK0 ≠ sK0 := superpose step14 step11
+  subsumption step21 rfl
 
 
 @[equational_result]
@@ -1747,7 +1795,8 @@ theorem Finite.Equation707_implies_Equation1316 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq13 (X Y : G) : (Y ◇ (((Y ◇ X) ◇ Y) ◇ Y)) = X := by
+  have step11 : sK0 ≠ (sK1 ◇ (((sK1 ◇ sK0) ◇ sK1) ◇ sK1)) := mod_symm nh
+  have step14 (X Y : G) : (Y ◇ (((Y ◇ X) ◇ Y) ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (Y ◇ ((s ◇ Y) ◇ Y))) S := by
       intro
@@ -1764,8 +1813,8 @@ theorem Finite.Equation707_implies_Equation1316 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : sK0 ≠ (sK1 ◇ (((sK1 ◇ sK0) ◇ sK1) ◇ sK1)) := mod_symm nh
-  subsumption eq14 eq13
+  have step21 : sK0 ≠ sK0 := superpose step14 step11
+  subsumption step21 rfl
 
 
 @[equational_result]
@@ -1773,7 +1822,8 @@ theorem Finite.Equation707_implies_Equation2238 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq11 (X Y : G) : ((Y ◇ (Y ◇ (X ◇ Y))) ◇ Y) = X := by
+  have step11 : sK0 ≠ ((sK0 ◇ (sK0 ◇ (sK0 ◇ sK0))) ◇ sK0) := mod_symm nh
+  have step12 (X Y : G) : ((Y ◇ (Y ◇ (X ◇ Y))) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -1790,8 +1840,8 @@ theorem Finite.Equation707_implies_Equation2238 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : sK0 ≠ ((sK0 ◇ (sK0 ◇ (sK0 ◇ sK0))) ◇ sK0) := mod_symm nh
-  subsumption eq14 eq11
+  have step18 : sK0 ≠ sK0 := superpose step12 step11
+  subsumption step18 rfl
 
 
 @[equational_result]
@@ -1799,15 +1849,16 @@ theorem Finite.Equation707_implies_Equation2940 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq12 (X Y : G) : (((Y ◇ (Y ◇ X)) ◇ Y) ◇ Y) = X := by
+  have step11 : sK0 ≠ (((sK1 ◇ (sK1 ◇ sK0)) ◇ sK1) ◇ sK1) := mod_symm nh
+  have step12 (X Y : G) : ((Y ◇ (Y ◇ (X ◇ Y))) ◇ Y) = X := by
     let S : Set G := Set.univ
-    have m1 : S.MapsTo (fun s => ((s ◇ Y) ◇ Y)) S := by
+    have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
       simp [S]
-    have m2 : S.MapsTo (fun s => (Y ◇ (Y ◇ s))) S := by
+    have m2 : S.MapsTo (fun s => (Y ◇ (Y ◇ (s ◇ Y)))) S := by
       intro
       simp [S]
-    have linv : S.LeftInvOn (fun s => (Y ◇ (Y ◇ s))) (fun s => ((s ◇ Y) ◇ Y)) := by
+    have linv : S.LeftInvOn (fun s => (Y ◇ (Y ◇ (s ◇ Y)))) (fun s => (s ◇ Y)) := by
       intro a ha
       simp [S]
       simp [← h]
@@ -1816,8 +1867,9 @@ theorem Finite.Equation707_implies_Equation2940 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq14 : sK0 ≠ (((sK1 ◇ (sK1 ◇ sK0)) ◇ sK1) ◇ sK1) := mod_symm nh
-  subsumption eq14 eq12
+  have step17 (X0 X1 : G) : ((X1 ◇ (X1 ◇ X0)) ◇ X1) = (X1 ◇ (X1 ◇ (X0 ◇ X1))) := superpose step12 step12
+  have step19 : sK0 ≠ ((sK1 ◇ (sK1 ◇ (sK0 ◇ sK1))) ◇ sK1) := superpose step17 step11
+  subsumption step19 step12
 
 
 @[equational_result]
@@ -1825,8 +1877,9 @@ theorem Finite.Equation713_implies_Equation1426 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq9 (X0 X1 : G) : (X1 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0))) = X0 := mod_symm (h ..)
-  have eq10 (X Y : G) : ((Y ◇ (Y ◇ (Y ◇ X))) ◇ (Y ◇ (Y ◇ X))) = X := by
+  have step9 (X0 X1 : G) : (X1 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0))) = X0 := mod_symm (h ..)
+  have step10 : sK0 ≠ ((sK0 ◇ sK0) ◇ (sK0 ◇ (sK0 ◇ sK0))) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (Y ◇ (Y ◇ X))) ◇ (Y ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => ((Y ◇ s) ◇ s)) S := by
       intro
@@ -1843,7 +1896,7 @@ theorem Finite.Equation713_implies_Equation1426 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq11 (X Y : G) : (Y ◇ ((Y ◇ (Y ◇ X)) ◇ (Y ◇ X))) = X := by
+  have step12 (X Y : G) : (Y ◇ ((Y ◇ (Y ◇ X)) ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (Y ◇ ((Y ◇ s) ◇ s))) S := by
       intro
@@ -1860,21 +1913,20 @@ theorem Finite.Equation713_implies_Equation1426 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((sK0 ◇ sK0) ◇ (sK0 ◇ (sK0 ◇ sK0))) := mod_symm nh
-  have eq14 (X0 X1 : G) : ((X1 ◇ X0) ◇ X0) = (X1 ◇ (X0 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0)))) := superpose eq9 eq11
-  have eq15 (X0 X1 : G) : (X1 ◇ ((X1 ◇ X0) ◇ X0)) = ((X1 ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0)) := superpose eq11 eq11
-  have eq21 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0))))) := superpose eq10 eq9
-  have eq26 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ X0) := superpose eq9 eq14
-  have eq39 (X0 X1 : G) : ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0)))) = (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0) ◇ X0) := superpose eq10 eq15
-  have eq54 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0) ◇ X0)) := superpose eq39 eq21
-  have eq64 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ X0))) = X0 := superpose eq26 eq9
-  have eq67 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = X0 := superpose eq26 eq64
-  have eq75 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ X0)) = (((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ ((((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ X0) ◇ X0)) := superpose eq26 eq54
-  have eq90 (X0 : G) : (X0 ◇ ((X0 ◇ X0) ◇ X0)) = ((X0 ◇ X0) ◇ (X0 ◇ X0)) := superpose eq67 eq75
-  have eq91 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ X0) ◇ (X0 ◇ X0)) := superpose eq26 eq90
-  have eq93 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ (X0 ◇ X0))) = X0 := superpose eq91 eq67
-  have eq158 : sK0 ≠ sK0 := superpose eq93 eq12
-  subsumption eq158 rfl
+  have step14 (X0 X1 : G) : ((X1 ◇ X0) ◇ X0) = (X1 ◇ (X0 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0)))) := superpose step9 step12
+  have step15 (X0 X1 : G) : (X1 ◇ ((X1 ◇ X0) ◇ X0)) = ((X1 ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0)) := superpose step12 step12
+  have step21 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0))))) := superpose step11 step9
+  have step26 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ X0) := superpose step9 step14
+  have step39 (X0 X1 : G) : ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0)))) = (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0) ◇ X0) := superpose step11 step15
+  have step54 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0) ◇ X0)) := superpose step39 step21
+  have step64 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ X0))) = X0 := superpose step26 step9
+  have step67 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = X0 := superpose step26 step64
+  have step75 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ X0)) = (((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ ((((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ X0) ◇ X0)) := superpose step26 step54
+  have step90 (X0 : G) : (X0 ◇ ((X0 ◇ X0) ◇ X0)) = ((X0 ◇ X0) ◇ (X0 ◇ X0)) := superpose step67 step75
+  have step91 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ X0) ◇ (X0 ◇ X0)) := superpose step26 step90
+  have step93 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ (X0 ◇ X0))) = X0 := superpose step91 step67
+  have step158 : sK0 ≠ sK0 := superpose step93 step10
+  subsumption step158 rfl
 
 
 @[equational_result]
@@ -1882,8 +1934,9 @@ theorem Finite.Equation713_implies_Equation359 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq9 (X0 X1 : G) : (X1 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0))) = X0 := mod_symm (h ..)
-  have eq11 (X Y : G) : (Y ◇ ((Y ◇ (Y ◇ X)) ◇ (Y ◇ X))) = X := by
+  have step9 (X0 X1 : G) : (X1 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0))) = X0 := mod_symm (h ..)
+  have step10 : (sK0 ◇ sK0) ≠ ((sK0 ◇ sK0) ◇ sK0) := mod_symm nh
+  have step12 (X Y : G) : (Y ◇ ((Y ◇ (Y ◇ X)) ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (Y ◇ ((Y ◇ s) ◇ s))) S := by
       intro
@@ -1900,11 +1953,10 @@ theorem Finite.Equation713_implies_Equation359 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : (sK0 ◇ sK0) ≠ ((sK0 ◇ sK0) ◇ sK0) := mod_symm nh
-  have eq14 (X0 X1 : G) : ((X1 ◇ X0) ◇ X0) = (X1 ◇ (X0 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0)))) := superpose eq9 eq11
-  have eq26 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ X0) := superpose eq9 eq14
-  have eq65 : (sK0 ◇ sK0) ≠ (sK0 ◇ sK0) := superpose eq26 eq12
-  subsumption eq65 rfl
+  have step14 (X0 X1 : G) : ((X1 ◇ X0) ◇ X0) = (X1 ◇ (X0 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0)))) := superpose step9 step12
+  have step26 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ X0) := superpose step9 step14
+  have step65 : (sK0 ◇ sK0) ≠ (sK0 ◇ sK0) := superpose step26 step10
+  subsumption step65 rfl
 
 
 @[equational_result]
@@ -1912,8 +1964,9 @@ theorem Finite.Equation713_implies_Equation3862 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq9 (X0 X1 : G) : (X1 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0))) = X0 := mod_symm (h ..)
-  have eq10 (X Y : G) : ((Y ◇ (Y ◇ (Y ◇ X))) ◇ (Y ◇ (Y ◇ X))) = X := by
+  have step9 (X0 X1 : G) : (X1 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0))) = X0 := mod_symm (h ..)
+  have step10 : (sK0 ◇ sK0) ≠ ((sK0 ◇ (sK0 ◇ sK0)) ◇ sK0) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (Y ◇ (Y ◇ X))) ◇ (Y ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => ((Y ◇ s) ◇ s)) S := by
       intro
@@ -1930,7 +1983,7 @@ theorem Finite.Equation713_implies_Equation3862 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq11 (X Y : G) : (Y ◇ ((Y ◇ (Y ◇ X)) ◇ (Y ◇ X))) = X := by
+  have step12 (X Y : G) : (Y ◇ ((Y ◇ (Y ◇ X)) ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (Y ◇ ((Y ◇ s) ◇ s))) S := by
       intro
@@ -1947,33 +2000,32 @@ theorem Finite.Equation713_implies_Equation3862 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : (sK0 ◇ sK0) ≠ ((sK0 ◇ (sK0 ◇ sK0)) ◇ sK0) := mod_symm nh
-  have eq14 (X0 X1 : G) : ((X1 ◇ X0) ◇ X0) = (X1 ◇ (X0 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0)))) := superpose eq9 eq11
-  have eq15 (X0 X1 : G) : (X1 ◇ ((X1 ◇ X0) ◇ X0)) = ((X1 ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0)) := superpose eq11 eq11
-  have eq20 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0)) ◇ ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0)) := superpose eq10 eq10
-  have eq21 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0))))) := superpose eq10 eq9
-  have eq26 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ X0) := superpose eq9 eq14
-  have eq28 (X0 : G) : (X0 ◇ ((X0 ◇ X0) ◇ X0)) = ((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ ((X0 ◇ X0) ◇ X0)) := superpose eq14 eq10
-  have eq35 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ X0)) := superpose eq26 eq28
-  have eq39 (X0 X1 : G) : ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0)))) = (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0) ◇ X0) := superpose eq10 eq15
-  have eq54 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0) ◇ X0)) := superpose eq39 eq21
-  have eq64 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ X0))) = X0 := superpose eq26 eq9
-  have eq67 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = X0 := superpose eq26 eq64
-  have eq75 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ X0)) = (((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ ((((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ X0) ◇ X0)) := superpose eq26 eq54
-  have eq77 (X0 : G) : ((X0 ◇ X0) ◇ X0) = ((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ (((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ (X0 ◇ ((X0 ◇ X0) ◇ X0))) ◇ (X0 ◇ ((X0 ◇ X0) ◇ X0)))) := superpose eq14 eq54
-  have eq90 (X0 : G) : (X0 ◇ ((X0 ◇ X0) ◇ X0)) = ((X0 ◇ X0) ◇ (X0 ◇ X0)) := superpose eq67 eq75
-  have eq91 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ X0) ◇ (X0 ◇ X0)) := superpose eq26 eq90
-  have eq93 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ (X0 ◇ X0))) = X0 := superpose eq91 eq67
-  have eq95 (X0 : G) : ((X0 ◇ X0) ◇ X0) = ((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ ((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ (X0 ◇ ((X0 ◇ X0) ◇ X0)))) := superpose eq26 eq77
-  have eq96 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0)))) := superpose eq26 eq95
-  have eq184 (X0 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) = ((((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0)))) ◇ (((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0)))) ◇ (X0 ◇ X0))) ◇ (((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0)))) ◇ (X0 ◇ X0))) := superpose eq35 eq20
-  have eq191 (X0 : G) : (((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) := superpose eq96 eq184
-  have eq192 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) := superpose eq35 eq191
-  have eq193 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ (X0 ◇ X0))) = ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) := superpose eq91 eq192
-  have eq194 (X0 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) = X0 := superpose eq93 eq193
-  have eq196 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ (X0 ◇ X0)) ◇ X0) := superpose eq194 eq96
-  have eq212 : (sK0 ◇ sK0) ≠ (sK0 ◇ sK0) := superpose eq196 eq12
-  subsumption eq212 rfl
+  have step14 (X0 X1 : G) : ((X1 ◇ X0) ◇ X0) = (X1 ◇ (X0 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0)))) := superpose step9 step12
+  have step15 (X0 X1 : G) : (X1 ◇ ((X1 ◇ X0) ◇ X0)) = ((X1 ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0)) := superpose step12 step12
+  have step20 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0)) ◇ ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0)) := superpose step11 step11
+  have step21 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0))))) := superpose step11 step9
+  have step26 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ X0) := superpose step9 step14
+  have step28 (X0 : G) : (X0 ◇ ((X0 ◇ X0) ◇ X0)) = ((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ ((X0 ◇ X0) ◇ X0)) := superpose step14 step11
+  have step35 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ X0)) := superpose step26 step28
+  have step39 (X0 X1 : G) : ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0)))) = (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0) ◇ X0) := superpose step11 step15
+  have step54 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0) ◇ X0)) := superpose step39 step21
+  have step64 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ X0))) = X0 := superpose step26 step9
+  have step67 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = X0 := superpose step26 step64
+  have step75 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ X0)) = (((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ ((((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ X0) ◇ X0)) := superpose step26 step54
+  have step77 (X0 : G) : ((X0 ◇ X0) ◇ X0) = ((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ (((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ (X0 ◇ ((X0 ◇ X0) ◇ X0))) ◇ (X0 ◇ ((X0 ◇ X0) ◇ X0)))) := superpose step14 step54
+  have step90 (X0 : G) : (X0 ◇ ((X0 ◇ X0) ◇ X0)) = ((X0 ◇ X0) ◇ (X0 ◇ X0)) := superpose step67 step75
+  have step91 (X0 : G) : (X0 ◇ (X0 ◇ X0)) = ((X0 ◇ X0) ◇ (X0 ◇ X0)) := superpose step26 step90
+  have step93 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ (X0 ◇ X0))) = X0 := superpose step91 step67
+  have step95 (X0 : G) : ((X0 ◇ X0) ◇ X0) = ((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ ((X0 ◇ ((X0 ◇ X0) ◇ X0)) ◇ (X0 ◇ ((X0 ◇ X0) ◇ X0)))) := superpose step26 step77
+  have step96 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0)))) := superpose step26 step95
+  have step184 (X0 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) = ((((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0)))) ◇ (((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0)))) ◇ (X0 ◇ X0))) ◇ (((X0 ◇ (X0 ◇ X0)) ◇ ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0)))) ◇ (X0 ◇ X0))) := superpose step35 step20
+  have step191 (X0 : G) : (((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) := superpose step96 step184
+  have step192 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) := superpose step35 step191
+  have step193 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ (X0 ◇ X0))) = ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) := superpose step91 step192
+  have step194 (X0 : G) : ((X0 ◇ (X0 ◇ X0)) ◇ (X0 ◇ (X0 ◇ X0))) = X0 := superpose step93 step193
+  have step196 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ (X0 ◇ X0)) ◇ X0) := superpose step194 step96
+  have step212 : (sK0 ◇ sK0) ≠ (sK0 ◇ sK0) := superpose step196 step10
+  subsumption step212 rfl
 
 
 @[equational_result]
@@ -1981,8 +2033,9 @@ theorem Finite.Equation713_implies_Equation817 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq9 (X0 X1 : G) : (X1 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0))) = X0 := mod_symm (h ..)
-  have eq10 (X Y : G) : ((Y ◇ (Y ◇ (Y ◇ X))) ◇ (Y ◇ (Y ◇ X))) = X := by
+  have step9 (X0 X1 : G) : (X1 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0))) = X0 := mod_symm (h ..)
+  have step10 : sK0 ≠ (sK0 ◇ ((sK0 ◇ sK0) ◇ (sK0 ◇ sK0))) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (Y ◇ (Y ◇ X))) ◇ (Y ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => ((Y ◇ s) ◇ s)) S := by
       intro
@@ -1999,7 +2052,7 @@ theorem Finite.Equation713_implies_Equation817 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq11 (X Y : G) : (Y ◇ ((Y ◇ (Y ◇ X)) ◇ (Y ◇ X))) = X := by
+  have step12 (X Y : G) : (Y ◇ ((Y ◇ (Y ◇ X)) ◇ (Y ◇ X))) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (Y ◇ ((Y ◇ s) ◇ s))) S := by
       intro
@@ -2016,21 +2069,20 @@ theorem Finite.Equation713_implies_Equation817 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (sK0 ◇ ((sK0 ◇ sK0) ◇ (sK0 ◇ sK0))) := mod_symm nh
-  have eq14 (X0 X1 : G) : ((X1 ◇ X0) ◇ X0) = (X1 ◇ (X0 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0)))) := superpose eq9 eq11
-  have eq15 (X0 X1 : G) : (X1 ◇ ((X1 ◇ X0) ◇ X0)) = ((X1 ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0)) := superpose eq11 eq11
-  have eq21 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0))))) := superpose eq10 eq9
-  have eq26 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ X0) := superpose eq9 eq14
-  have eq39 (X0 X1 : G) : ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0)))) = (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0) ◇ X0) := superpose eq10 eq15
-  have eq54 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0) ◇ X0)) := superpose eq39 eq21
-  have eq60 (X0 : G) : (X0 ◇ (X0 ◇ (X0 ◇ X0))) = X0 := superpose eq26 eq9
-  have eq64 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ X0))) = X0 := superpose eq26 eq9
-  have eq67 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = X0 := superpose eq26 eq64
-  have eq75 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ X0)) = (((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ ((((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ X0) ◇ X0)) := superpose eq26 eq54
-  have eq90 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ X0)) = (X0 ◇ ((X0 ◇ X0) ◇ X0)) := superpose eq67 eq75
-  have eq91 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ X0)) = (X0 ◇ (X0 ◇ X0)) := superpose eq26 eq90
-  have eq94 : sK0 ≠ (sK0 ◇ (sK0 ◇ (sK0 ◇ sK0))) := superpose eq91 eq12
-  subsumption eq94 eq60
+  have step14 (X0 X1 : G) : ((X1 ◇ X0) ◇ X0) = (X1 ◇ (X0 ◇ (X1 ◇ ((X1 ◇ X0) ◇ X0)))) := superpose step9 step12
+  have step15 (X0 X1 : G) : (X1 ◇ ((X1 ◇ X0) ◇ X0)) = ((X1 ◇ (X1 ◇ X0)) ◇ (X1 ◇ X0)) := superpose step12 step12
+  have step21 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0))))) := superpose step11 step9
+  have step26 (X0 : G) : (X0 ◇ X0) = ((X0 ◇ X0) ◇ X0) := superpose step9 step14
+  have step39 (X0 X1 : G) : ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (X0 ◇ (X1 ◇ (X1 ◇ X0)))) = (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0) ◇ X0) := superpose step11 step15
+  have step54 (X0 X1 : G) : (X1 ◇ (X1 ◇ X0)) = ((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ (((X1 ◇ (X1 ◇ (X1 ◇ X0))) ◇ X0) ◇ X0)) := superpose step39 step21
+  have step60 (X0 : G) : (X0 ◇ (X0 ◇ (X0 ◇ X0))) = X0 := superpose step26 step9
+  have step64 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ X0))) = X0 := superpose step26 step9
+  have step67 (X0 : G) : ((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) = X0 := superpose step26 step64
+  have step75 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ X0)) = (((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ ((((X0 ◇ X0) ◇ ((X0 ◇ X0) ◇ (X0 ◇ X0))) ◇ X0) ◇ X0)) := superpose step26 step54
+  have step90 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ X0)) = (X0 ◇ ((X0 ◇ X0) ◇ X0)) := superpose step67 step75
+  have step91 (X0 : G) : ((X0 ◇ X0) ◇ (X0 ◇ X0)) = (X0 ◇ (X0 ◇ X0)) := superpose step26 step90
+  have step94 : sK0 ≠ (sK0 ◇ (sK0 ◇ (sK0 ◇ sK0))) := superpose step91 step10
+  subsumption step94 step60
 
 
 @[equational_result]
@@ -2038,15 +2090,17 @@ theorem Finite.Equation73_implies_Equation125 (G : Type*) [Magma G] [Finite G] (
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq11 (X Y : G) : (Y ◇ ((Y ◇ X) ◇ Y)) = X := by
+  have step9 (X0 X1 : G) : (X1 ◇ (X1 ◇ (X0 ◇ X1))) = X0 := mod_symm (h ..)
+  have step10 : sK0 ≠ (sK1 ◇ ((sK1 ◇ sK0) ◇ sK1)) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (Y ◇ X)) ◇ Y) = X := by
     let S : Set G := Set.univ
-    have m1 : S.MapsTo (fun s => (Y ◇ (s ◇ Y))) S := by
+    have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
       simp [S]
-    have m2 : S.MapsTo (fun s => (Y ◇ s)) S := by
+    have m2 : S.MapsTo (fun s => (Y ◇ (Y ◇ s))) S := by
       intro
       simp [S]
-    have linv : S.LeftInvOn (fun s => (Y ◇ s)) (fun s => (Y ◇ (s ◇ Y))) := by
+    have linv : S.LeftInvOn (fun s => (Y ◇ (Y ◇ s))) (fun s => (s ◇ Y)) := by
       intro a ha
       simp [S]
       simp [← h]
@@ -2055,8 +2109,9 @@ theorem Finite.Equation73_implies_Equation125 (G : Type*) [Magma G] [Finite G] (
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ (sK1 ◇ ((sK1 ◇ sK0) ◇ sK1)) := mod_symm nh
-  subsumption eq12 eq11
+  have step14 (X0 X1 : G) : (X1 ◇ (X0 ◇ X1)) = ((X1 ◇ X0) ◇ X1) := superpose step9 step11
+  have step17 : sK0 ≠ (sK1 ◇ (sK1 ◇ (sK0 ◇ sK1))) := superpose step14 step10
+  subsumption step17 step9
 
 
 @[equational_result]
@@ -2064,7 +2119,8 @@ theorem Finite.Equation73_implies_Equation229 (G : Type*) [Magma G] [Finite G] (
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq10 (X Y : G) : ((Y ◇ (Y ◇ X)) ◇ Y) = X := by
+  have step10 : sK0 ≠ ((sK1 ◇ (sK1 ◇ sK0)) ◇ sK1) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (Y ◇ X)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -2081,8 +2137,8 @@ theorem Finite.Equation73_implies_Equation229 (G : Type*) [Magma G] [Finite G] (
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((sK1 ◇ (sK1 ◇ sK0)) ◇ sK1) := mod_symm nh
-  subsumption eq12 eq10
+  have step16 : sK0 ≠ sK0 := superpose step11 step10
+  subsumption step16 rfl
 
 
 @[equational_result]
@@ -2090,8 +2146,9 @@ theorem Finite.Equation73_implies_Equation4435 (G : Type*) [Magma G] [Finite G] 
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq9 (X0 X1 : G) : (X1 ◇ (X1 ◇ (X0 ◇ X1))) = X0 := mod_symm (h ..)
-  have eq10 (X Y : G) : ((Y ◇ (Y ◇ X)) ◇ Y) = X := by
+  have step9 (X0 X1 : G) : (X1 ◇ (X1 ◇ (X0 ◇ X1))) = X0 := mod_symm (h ..)
+  have step10 : (sK0 ◇ (sK1 ◇ sK0)) ≠ ((sK0 ◇ sK1) ◇ sK0) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (Y ◇ X)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -2108,10 +2165,9 @@ theorem Finite.Equation73_implies_Equation4435 (G : Type*) [Magma G] [Finite G] 
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : (sK0 ◇ (sK1 ◇ sK0)) ≠ ((sK0 ◇ sK1) ◇ sK0) := mod_symm nh
-  have eq14 (X0 X1 : G) : (X1 ◇ (X0 ◇ X1)) = ((X1 ◇ X0) ◇ X1) := superpose eq9 eq10
-  have eq22 : (sK0 ◇ (sK1 ◇ sK0)) ≠ (sK0 ◇ (sK1 ◇ sK0)) := superpose eq14 eq12
-  subsumption eq22 rfl
+  have step14 (X0 X1 : G) : (X1 ◇ (X0 ◇ X1)) = ((X1 ◇ X0) ◇ X1) := superpose step9 step11
+  have step22 : (sK0 ◇ (sK1 ◇ sK0)) ≠ (sK0 ◇ (sK1 ◇ sK0)) := superpose step14 step10
+  subsumption step22 rfl
 
 
 @[equational_result]
@@ -2119,7 +2175,8 @@ theorem Finite.Equation883_implies_Equation2304 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq10 (X Y : G) : ((Y ◇ (X ◇ (Y ◇ Y))) ◇ Y) = X := by
+  have step10 : sK0 ≠ ((sK1 ◇ (sK0 ◇ (sK1 ◇ sK1))) ◇ sK1) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ (X ◇ (Y ◇ Y))) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -2136,8 +2193,8 @@ theorem Finite.Equation883_implies_Equation2304 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((sK1 ◇ (sK0 ◇ (sK1 ◇ sK1))) ◇ sK1) := mod_symm nh
-  subsumption eq12 eq10
+  have step16 : sK0 ≠ sK0 := superpose step11 step10
+  subsumption step16 rfl
 
 
 @[equational_result]
@@ -2145,7 +2202,8 @@ theorem Finite.Equation917_implies_Equation1629 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, nh⟩ := nh
-  have eq11 (X Y : G) : ((Y ◇ Y) ◇ ((Y ◇ X) ◇ Y)) = X := by
+  have step10 : sK0 ≠ ((sK0 ◇ sK0) ◇ ((sK0 ◇ sK0) ◇ sK0)) := mod_symm nh
+  have step12 (X Y : G) : ((Y ◇ Y) ◇ ((Y ◇ X) ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => ((Y ◇ Y) ◇ (s ◇ Y))) S := by
       intro
@@ -2162,8 +2220,8 @@ theorem Finite.Equation917_implies_Equation1629 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((sK0 ◇ sK0) ◇ ((sK0 ◇ sK0) ◇ sK0)) := mod_symm nh
-  subsumption eq12 eq11
+  have step17 : sK0 ≠ sK0 := superpose step12 step10
+  subsumption step17 rfl
 
 
 @[equational_result]
@@ -2171,7 +2229,8 @@ theorem Finite.Equation917_implies_Equation1729 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq11 (X Y : G) : ((Y ◇ Y) ◇ ((Y ◇ X) ◇ Y)) = X := by
+  have step10 : sK0 ≠ ((sK1 ◇ sK1) ◇ ((sK1 ◇ sK0) ◇ sK1)) := mod_symm nh
+  have step12 (X Y : G) : ((Y ◇ Y) ◇ ((Y ◇ X) ◇ Y)) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => ((Y ◇ Y) ◇ (s ◇ Y))) S := by
       intro
@@ -2188,8 +2247,8 @@ theorem Finite.Equation917_implies_Equation1729 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((sK1 ◇ sK1) ◇ ((sK1 ◇ sK0) ◇ sK1)) := mod_symm nh
-  subsumption eq12 eq11
+  have step17 : sK0 ≠ sK0 := superpose step12 step10
+  subsumption step17 rfl
 
 
 @[equational_result]
@@ -2197,7 +2256,8 @@ theorem Finite.Equation917_implies_Equation2541 (G : Type*) [Magma G] [Finite G]
   by_contra nh
   simp only [not_forall] at nh
   obtain ⟨sK0, sK1, nh⟩ := nh
-  have eq10 (X Y : G) : ((Y ◇ ((Y ◇ Y) ◇ X)) ◇ Y) = X := by
+  have step10 : sK0 ≠ ((sK1 ◇ ((sK1 ◇ sK1) ◇ sK0)) ◇ sK1) := mod_symm nh
+  have step11 (X Y : G) : ((Y ◇ ((Y ◇ Y) ◇ X)) ◇ Y) = X := by
     let S : Set G := Set.univ
     have m1 : S.MapsTo (fun s => (s ◇ Y)) S := by
       intro
@@ -2214,5 +2274,7 @@ theorem Finite.Equation917_implies_Equation2541 (G : Type*) [Magma G] [Finite G]
     have rinv := Set.InjOn.rightInvOn_of_leftInvOn t.injOn linv m2 m1
     apply rinv _
     simp [S]
-  have eq12 : sK0 ≠ ((sK1 ◇ ((sK1 ◇ sK1) ◇ sK0)) ◇ sK1) := mod_symm nh
-  subsumption eq12 eq10
+  have step15 : sK0 ≠ sK0 := superpose step11 step10
+  subsumption step15 rfl
+
+


### PR DESCRIPTION
In this change I add the ability to search using injectivity<=>surjectivity as well as a periodicity heuristic.

I re-generated the proofs to match the current codegen style, but this change has no functional changes to the proven state of the finite graph.