### PR TITLE
Fix typo in Equation 1692 description

### DIFF
--- a/commentary/Equation1692.md
+++ b/commentary/Equation1692.md
@@ -1,5 +1,5 @@
 ## The "Dupond" equation
 
-Closely related to the ["Dupont" equation, 1692](https://teorth.github.io/equational_theories/implications/?1692).  In particular, the "Dupond" equation implies the "Dupont" equation for finite magmas, but not for infinite ones.  See [this discussion](https://leanprover.zulipchat.com/#narrow/stream/458659-Equational/topic/Proposed.20new.20target.3A.2063.20and.201692.20.28.22Dupont.20and.20Dupond.22.29).
+Closely related to the ["Dupont" equation, 63](https://teorth.github.io/equational_theories/implications/?63).  In particular, the "Dupond" equation implies the "Dupont" equation for finite magmas, but not for infinite ones.  See [this discussion](https://leanprover.zulipchat.com/#narrow/stream/458659-Equational/topic/Proposed.20new.20target.3A.2063.20and.201692.20.28.22Dupont.20and.20Dupond.22.29).
 
 This pair shares many similarities with the "Asterix" ([equation 65](https://teorth.github.io/equational_theories/implications/?65)) and "Obelix" ([equation 1491](https://teorth.github.io/equational_theories/implications/?1491)) pair.


### PR DESCRIPTION
The page was linking to itself rather than the correct page.