### PR TITLE
Correct the max size of (non-1286) non-trivial finite models to 5

### DIFF
--- a/paper/constructions.tex
+++ b/paper/constructions.tex
@@ -13,7 +13,7 @@ For specific refutations, it was sometimes possible to locate a finite example w
 
 \note{Discuss this further, perhaps give an example, or refer to the ATP section.  See also the discussion threads ``Counterexamples by enumerating words in quotient magmas'' and ``Using SAT solvers for model generation'' threads (sorry, LaTeX is choking on the URLs for some reason).}
 
-It is a result of Kisielewicz \cite{Kisielewicz} that every law $En$ with $n \leq 4692$ is either equivalent to the singleton law $E2$, or else has a non-trivial finite model.  In fact our brute force search revealed that in the latter case there is always a model of order $2 \leq n \leq 4$, with the lone exception of \eqref{eq1286} (and its dual \eqref{eq2301}), for which the smallest non-trivial finite model was of order $7$, as presented in \Cref{1286-ex} below.
+It is a result of Kisielewicz \cite{Kisielewicz} that every law $En$ with $n \leq 4692$ is either equivalent to the singleton law $E2$, or else has a non-trivial finite model.  In fact our brute force search revealed that in the latter case there is always a model of order $2 \leq n \leq 5$, with the lone exception of \eqref{eq1286} (and its dual \eqref{eq2301}), for which the smallest non-trivial finite model was of order $7$, as presented in \Cref{1286-ex} below.
 
 \subsection{Linear models}\label{linear-sec}
 


### PR DESCRIPTION
> In fact our brute force search revealed that in the latter case there is always a model of order $2 \leq n \leq 4$, with the lone exception of \eqref{eq1286} (and its dual \eqref{eq2301}), for which the smallest non-trivial finite model was of order $7$, as presented in \Cref{1286-ex} below.

4 should be 5 here, we have several magmas with smallest non-trivial finite model size of 5 (e.g. the outstanding 677).  

Actually, even just saying 2-5 kind of understates how dominant 2 is (counts of {2: 3136, 3: 32, 4: 14, 5: 14, 7: 2} according to smallest_magma.txt), but with 5 at least it's true. :-)