### PR TITLE
Correct an important error in Tarski commentary

### DIFF
--- a/commentary/Equation543.md
+++ b/commentary/Equation543.md
@@ -1,8 +1,5 @@
-## Tarski's axiom
+## Tarski's axiom: the abelian group subtraction law
 
-This law was identified by Tarski [1] as the law for abelian groups; the models are precisely abelian groups with the subtraction operation `x ◇ y = x - y`.  This is the shortest possible law with this property [2].
-
-Besides law 543 and its dual, the other equivalent characterizations of minimal order are law 928, `x = y ◇ ((y◇z) ◇ (x◇z))`, identified by [Sholander](https://doi.org/10.2307/2310005), law 952 `x = y ◇ ((z◇x) ◇ (z◇y))`, identified by [Higman and Neumann](https://doi.org/10.5486/PMD.1952.2.3-4.10), and their duals.  The fact that there are no others was shown by [Padmanabhan](https://doi.org/10.1017/S144678870000570X).
+Magmas satisfying this law are precisely abelian groups with the subtraction operation `x ◇ y = x - y`.  There are six equivalent laws of [minimal order](https://www.cs.unm.edu/~mccune/projects/gtsax/#Tarski-1938), each with three variables: law 543 identified by Tarski [1]; law 928 identified by [Sholander](https://doi.org/10.2307/2310005); law 952 identified by [Higman and Neumann](https://doi.org/10.5486/PMD.1952.2.3-4.10); and laws 1774, 1964, 2552, identified and shown to be the only remaining ones by [Padmanabhan](https://doi.org/10.1017/S144678870000570X).
 
 1. A. Tarski. Ein Beitrag zur Axiomatik der Abelschen Gruppen. Fundamenta Mathematicae, 30:253--256, 1938.
-2. https://www.cs.unm.edu/~mccune/projects/gtsax/#Tarski-1938


### PR DESCRIPTION
When writing the previous version I mistakenly thought that the equation is equivalent to its dual, but of course subtraction and backwards subtraction are different operations.