### PR TITLE
Commentary on modules over Gaussian/Eisenstein integers

### DIFF
--- a/commentary/Equation163669.md
+++ b/commentary/Equation163669.md
@@ -1,6 +1,6 @@
 ## A law for groups of exponent 3
 
-Laws characterizing the operation in groups of exponent `n` must have an order that is a multiple of `n` strictly larger than `n`, as proven [by Kunen](https://doi.org/10.1016/0898-1221(94)00212-4).  The laws of minimal order are known for exponents 2, 4, and odd.
+Laws characterizing the operation in groups of exponent `n` (equivalently, `ℤ/nℤ`-modules) must have an order that is a multiple of `n` strictly larger than `n`, as proven [by Kunen](https://doi.org/10.1016/0898-1221(94)00212-4).  The laws of minimal order are known for exponents 2, 4, and odd.
 
 - For `n=2`, laws [895](https://teorth.github.io/equational_theories/implications/?895), 1334, 1571 as shown by [Mendelsohn and Padmanabhan](https://teorth.github.io/equational_theories/blueprint/sect0001.html#mendelsohn-padmanabhan), and their duals 2113, 2308, 2789.
 
@@ -11,3 +11,5 @@ Laws characterizing the operation in groups of exponent `n` must have an order t
 - For `n=5`, laws 9031790000, 10215810757 (the complete list being unknown), and for all odd `n` thanks to [McCune and Wos](https://doi.org/10.1007/BFb0013055).
 
 An important difference with the Higman-Neumann axiom for group division is that these laws concern group multiplication, which is enough to reconstruct the inverse because of the finite exponent.
+
+See also the [law 85914](https://teorth.github.io/equational_theories/implications/?85914) for modules over Eisenstein integers and [law 86082](https://teorth.github.io/equational_theories/implications/?86082) for modules over Gaussian integers.

--- a/commentary/Equation42903481.md
+++ b/commentary/Equation42903481.md
@@ -2,4 +2,4 @@
 
 It was shown by Kunen (The shortest single axioms for groups of exponent 4. *Computers and Mathematics with Applications,* 29:1-12, 1995) that this law characterizes groups of exponent 4.
 
-See law 1571 for groups of exponent 2 (which are automatically abelian) and law 163669 for groups of exponent 3.
+See law 1571 for groups of exponent 2 (which are automatically abelian) and law 163669 for groups of exponent 3 and further comments.

--- a/commentary/Equation543.md
+++ b/commentary/Equation543.md
@@ -2,4 +2,6 @@
 
 Magmas satisfying this law are precisely abelian groups with the subtraction operation `x ◇ y = x - y`.  There are six equivalent laws of [minimal order](https://www.cs.unm.edu/~mccune/projects/gtsax/#Tarski-1938), each with three variables: law 543 identified by Tarski [1]; law 928 identified by [Sholander](https://doi.org/10.2307/2310005); law 952 identified by [Higman and Neumann](https://doi.org/10.5486/PMD.1952.2.3-4.10); and laws 1774, 1964, 2552, identified and shown to be the only remaining ones by [Padmanabhan](https://doi.org/10.1017/S144678870000570X).
 
+Other laws from which one can define an abelian group structure on the module include [law 895](https://teorth.github.io/equational_theories/implications/?895) and [law 163669](https://teorth.github.io/equational_theories/implications/?163669) for abelian groups of exponents 2 and 3, and [law 85914](https://teorth.github.io/equational_theories/implications/?85914) and [law 86082](https://teorth.github.io/equational_theories/implications/?86082) for modules over Eisenstein integers and Gaussian integers, respectively.
+
 1. A. Tarski. Ein Beitrag zur Axiomatik der Abelschen Gruppen. Fundamenta Mathematicae, 30:253--256, 1938.

--- a/commentary/Equation85914.md
+++ b/commentary/Equation85914.md
@@ -1,0 +1,7 @@
+## The law for modules over the Eisenstein integers
+
+As [we discuss here](https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/The.20.22modules.20over.20Gaussian.20integers.22.20law/with/519928430), this order-6 law characterizes the operation `x ◇ y = x + ω y` in modules over the ring `ℤ[ω]` of Eisenstein integers, where `ω` is a primitive third root of unity.
+
+The equivalence class of this law among laws of order 6 has 18 to 48 members: the laws 85914, 86034, 130757, 130783, 131577, 131603, 144232, 194058, 264007, 264067, 268121, 268194, 279823, 280567, 300583, 337710, 383143, 461983 are equivalent; the laws 143049, 384114, 465969 are equivalent in the finite case but unknown in general; and the remaining candidates are 64470, 85063, 101569, 102829, 134897, 136009, 144378, 159529, 160421, 188509, 188563, 188673, 188793, 192959, 279873, 280541, 300369, 383089, 384365, 461957, 462803, 463072, 465889, 466797, 467298, 478363, 478590.
+
+See also the [Tarski law 543](https://teorth.github.io/equational_theories/implications/?543) for modules over ℤ (namely abelian groups), the [law 895](https://teorth.github.io/equational_theories/implications/?895) and [law 163669](https://teorth.github.io/equational_theories/implications/?163669) for modules over ℤ/2ℤ and ℤ/3ℤ, and [law 86082](https://teorth.github.io/equational_theories/implications/?86082) for modules over Gaussian integers.

--- a/commentary/Equation86082.md
+++ b/commentary/Equation86082.md
@@ -1,0 +1,7 @@
+## The law for modules over the Gaussian integers
+
+As [we discuss here](https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/The.20.22modules.20over.20Gaussian.20integers.22.20law/with/519928430), this order-6 law characterizes the operation `x ◇ y = x + i y` in modules over the ring `ℤ[i]` of Gaussian integers, where `i` is the square root of -1.
+
+The equivalence class of this law among laws of order 6 has 18 to 25 members: the laws 86082, 86160, 125935, 127386, 127464, 127560, 128214, 184602, 185406, 185442, 186339, 251586, 251959, 252414, 252439, 444561, 446262, 446340 are equivalent; the laws 86046, 86064, 444507, 446226, 446244 are only known to be equivalent in the finite case and their equivalence in the infinite case is unknown; and the remaining candidates are 127759, 183687.
+
+See also the [Tarski law 543](https://teorth.github.io/equational_theories/implications/?543) for modules over ℤ (namely abelian groups), the [law 895](https://teorth.github.io/equational_theories/implications/?895) and [law 163669](https://teorth.github.io/equational_theories/implications/?163669) for modules over ℤ/2ℤ and ℤ/3ℤ, and [law 85914](https://teorth.github.io/equational_theories/implications/?85914) for modules over Eisenstein integers.


### PR DESCRIPTION
Also mention for abelian groups and abelian groups with a given exponent that they are simply modules over ℤ or ℤ/nℤ, respectively.