### PR TITLE
fix filename to fix URLs

### DIFF
--- a/home_page/implications/show_proof.html
+++ b/home_page/implications/show_proof.html
@@ -84,7 +84,7 @@ if (isFiniteGraph) {
   let unconditionals = new Set(), all_eqs = new Set();
   let ctr = 0;
   for (const [filepath, entries] of Object.entries(full_entries)) {
-    const filename = filepath.replace(/^.*?equational_theories\//, "equational_theories/");
+    const filename = filepath.replace(/^.*equational_theories\//, "equational_theories/");
     for (const entry of entries) {
       const isConjecture = entry[1] === "?";
       const fields = entry.split("|");


### PR DESCRIPTION
"filename" gave an absolute path in the online version (e.g. click on Equation677_not_implies_Equation255 on https://teorth.github.io/equational_theories/implications/show_proof.html?pair=677,255 ). This should fix it.