### PR TITLE
[CONTRIBUTIONS] Port Bruno's equation numbering code to ruby.

### DIFF
--- a/scripts/find_equation_id.rb
+++ b/scripts/find_equation_id.rb
@@ -433,12 +433,6 @@ def get_rhyme_by_id(n, rhyme_num, max_used = 0)
   result
 end
 
-# Number of rhymes of n slots whose minimum number is at most max_used + 1
-def _num_rhyme_help(n, max_used)
-  return 1 if n == 0
-  (max_used + 1) * _num_rhyme_help(n - 1, max_used) + _num_rhyme_help(n - 1, max_used + 1)
-end
-
 # Gives the rhyme id (zero-based) among rhymes with a given number of variables
 def find_rhyme_id(p)
   raise ArgumentError, "Argument of find_rhyme_id should be [0,...] not #{p.inspect}" if p.empty? || p[0] != 0

--- a/scripts/find_equation_id.rb
+++ b/scripts/find_equation_id.rb
@@ -433,7 +433,6 @@ def get_rhyme_by_id(n, rhyme_num, max_used = 0)
   result
 end
 
-# Map from rhyme tp id and back
 # Number of rhymes of n slots whose minimum number is at most max_used + 1
 def _num_rhyme_help(n, max_used)
   return 1 if n == 0
@@ -637,7 +636,6 @@ def process_equation(eq_str)
       else
         puts "Equation #{input_eq}: #{eq}"
       end
-      #puts "Processing ID: #{input_eq}"  # placeholder for actual processing
     else
       input_eq = Equation.from_str(eq_str)
       if dual
@@ -648,7 +646,6 @@ def process_equation(eq_str)
         eq_num = input_eq.id
         puts "The equation '#{eq_str}' is Equation #{eq_num}: #{input_eq}"
       end
-      # puts "Processing: #{eq_str}"  # placeholder
     end
 end
 

--- a/scripts/find_equation_id.rb
+++ b/scripts/find_equation_id.rb
@@ -54,12 +54,12 @@ class Equation
     
     def to_s
       rhyme_enum = @rhyme.each
-      lhs_str = self.class.expr_str(@lhs_shape, rhyme_enum, false)
-      rhs_str = self.class.expr_str(@rhs_shape, rhyme_enum, false)
+      lhs_str = self.class._expr_str(@lhs_shape, rhyme_enum, false)
+      rhs_str = self.class._expr_str(@rhs_shape, rhyme_enum, false)
       "#{lhs_str} = #{rhs_str}"
     end
     
-    def self.expr_str(shape, rhyme_enum, parenthesize)
+    def self._expr_str(shape, rhyme_enum, parenthesize)
       if shape.nil?
         i, j = rhyme_enum.next.divmod(VAR_NAMES.length)
         if i == 0
@@ -67,8 +67,8 @@ class Equation
         end
         return VAR_NAMES[j] + i.to_s
       end
-      left_str = expr_str(shape[0], rhyme_enum, true)
-      right_str = expr_str(shape[1], rhyme_enum, true)
+      left_str = _expr_str(shape[0], rhyme_enum, true)
+      right_str = _expr_str(shape[1], rhyme_enum, true)
       if parenthesize
         "(#{left_str} ◇ #{right_str})"
       else

--- a/scripts/find_equation_id.rb
+++ b/scripts/find_equation_id.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 
 =begin
+This code is a port of find_equation_id.py
+
 This module maps magma equations from/to their id
 
 It can be used as a script in interactive mode (with the -i switch), as
@@ -9,12 +11,12 @@ It can be used as a script in interactive mode (with the -i switch), as
 
 or by passing arguments to it from stdin or as arguments: a (space-separated)
 list of ids or of equations (in which the operation can be ".", "*", or "◇"),
-optionally preceeded by "*" to dualize the equation (and characters "[,]" are
+optionally preceded by "*" to dualize the equation (and characters "[,]" are
 ignored):
 
     ruby find_equation_id.rb [12, 34] "(w*u)=t*(u*x)" 4567 "*89" "*67" "0=(1*2)*(0*1)"
 
-When used as a module imported in python code, one can use
+When this file is required as a module in another Ruby program, one can use
 - eq = Equation.from_id(integer id)
 - eq = Equation.from_str(string)
 - eq.id()

--- a/scripts/find_equation_id.rb
+++ b/scripts/find_equation_id.rb
@@ -1,0 +1,26 @@
+#!/usr/bin/env ruby
+
+=begin
+This module maps magma equations from/to their id
+
+It can be used as a script in interactive mode (with the -i switch), as
+
+    ruby find_equation_id.rb -i
+
+or by passing arguments to it from stdin or as arguments: a (space-separated)
+list of ids or of equations (in which the operation can be ".", "*", or "◇"),
+optionally preceeded by "*" to dualize the equation (and characters "[,]" are
+ignored):
+
+    ruby find_equation_id.rb [12, 34] "(w*u)=t*(u*x)" 4567 "*89" "*67" "0=(1*2)*(0*1)"
+
+When used as a module imported in python code, one can use
+- eq = Equation.from_id(integer id)
+- eq = Equation.from_str(string)
+- eq.id()
+- all_eqs(integer order)
+- eq.dual()
+
+The theory of magma operations and their labeling is explained in
+https://teorth.github.io/equational_theories/blueprint/basic-theory-chapter.html
+=end

--- a/scripts/find_equation_id.rb
+++ b/scripts/find_equation_id.rb
@@ -93,6 +93,16 @@ class Equation
       _equation_from_str(eq_str)
     end
     
+    def orders
+      # Returns the number of operations on the lhs and rhs as a tuple.
+      [shape_order(@lhs_shape), shape_order(@rhs_shape)]
+    end
+    
+    def num_vars
+      # Returns the number of distinct variables in the equation.
+      @rhyme.max + 1
+    end
+    
     def dual
       # Swap all left and right operands, swap lhs and rhs if needed
       lhs_shape = shape_dual(@lhs_shape)

--- a/scripts/find_equation_id.rb
+++ b/scripts/find_equation_id.rb
@@ -259,7 +259,7 @@ def shape_lt(shape1, shape2)
 end
 
 
-##### Generating all rhymes, all shapes, all equational_theories
+##### Generating all rhymes, all shapes, all equations
 def canonicalize_rhyme(rhyme)
   variables = {}
   rhyme.map do |x|

--- a/scripts/find_equation_id.rb
+++ b/scripts/find_equation_id.rb
@@ -32,8 +32,30 @@ VAR_NAMES = "xyzwuvrst"
 # ExprType: String, Integer, or [ExprType, String, ExprType]
 # ShapeType: nil or [ShapeType, ShapeType]
 
-def process_equation(eq)
-  puts "Processing: #{eq}"  # placeholder
+# Helper fuctions to supplement built in python methods not available in Ruby
+def strip_chars(str, chars)
+  pattern = /\A[#{Regexp.escape(chars)}]+|[#{Regexp.escape(chars)}]+\z/
+  str.gsub(pattern, '')
+end
+
+# Code used when module is used as a script
+
+def process_equation(eq_str)
+    # Process a given equation, printing its id and canonical form.
+    eq_str = strip_chars(eq_str, '[,]')
+    dual = false
+    if eq_str.start_with?("*")
+        dual = true
+        eq_str = eq_str[1..-1]
+    end
+
+    begin
+        input_eq = Integer(eq_str)
+    rescue ArgumentError
+        input_eq = nil
+    end
+
+    puts "Processing: #{eq_str}"  # placeholder
 end
 
 def main()

--- a/scripts/find_equation_id.rb
+++ b/scripts/find_equation_id.rb
@@ -330,7 +330,7 @@ def _equation_id(input_eq)
     all_rhymes(n + 1).each do |rhyme|
       break if rhyme == input_eq.rhyme
       flipped = rhyme[n_lhs + 1..] + rhyme[0..n_lhs]
-      next if canonicalize_rhyme(flipped) <=> rhyme == -1
+      next if (canonicalize_rhyme(flipped) <=> rhyme) == -1
       next if rhyme == flipped && n > 0
       pid += 1
     end

--- a/scripts/find_equation_id.rb
+++ b/scripts/find_equation_id.rb
@@ -24,3 +24,73 @@ When used as a module imported in python code, one can use
 The theory of magma operations and their labeling is explained in
 https://teorth.github.io/equational_theories/blueprint/basic-theory-chapter.html
 =end
+
+require 'optparse'
+
+VAR_NAMES = "xyzwuvrst"
+
+# ExprType: String, Integer, or [ExprType, String, ExprType]
+# ShapeType: nil or [ShapeType, ShapeType]
+
+def process_equation(eq)
+  puts "Processing: #{eq}"  # placeholder
+end
+
+def main()
+    # Main Functon to run the program
+
+    options = {}
+    parser = OptionParser.new do |opts|
+        opts.banner = "usage: find_equation_id.rb [-h] [--interactive] [equations ...]\n\n" +
+                "Canonicalize equations and find their numbers.\n\n"
+
+        opts.separator "positional arguments:"
+        opts.separator "  equations          The equations to canonicalize (if not in interactive mode)"
+        opts.separator ""
+
+        opts.separator "options:"
+
+        opts.on("-i", "--interactive", "Run in interactive mode") do
+            options[:interactive] = true
+        end
+
+        opts.on("-h", "--help", "show this help message and exit") do
+            puts opts
+            exit
+        end
+    end
+
+    parser.parse!
+    equations = ARGV
+
+    if options[:interactive]
+        puts "Welcome to the interactive equation canonicalizer!"
+        puts "Type 'exit' or 'quit' to end the session."
+
+        loop do
+            print "Enter an equation: "
+            eq = gets&.chomp
+            if eq.nil? || %w[exit quit].include?(eq.downcase)
+                puts "Goodbye!"
+                break
+            end
+            process_equation(eq)
+        end
+    else
+        # If stdin is piped (not a terminal)
+        unless $stdin.tty?
+            piped_equations = $stdin.each_line.flat_map { |line| line.split }
+            equations = piped_equations + equations
+        end
+
+        if equations.any?
+            equations.each { |eq| process_equation(eq) }
+        else
+            puts parser
+        end
+    end
+end
+
+if __FILE__ == $0
+  main()
+end

--- a/scripts/find_equation_id.rb
+++ b/scripts/find_equation_id.rb
@@ -32,10 +32,133 @@ VAR_NAMES = "xyzwuvrst"
 # ExprType: String, Integer, or [ExprType, String, ExprType]
 # ShapeType: nil or [ShapeType, ShapeType]
 
+class Equation()
+=begin
+    Equation(lhs_shape, rhs_shape, rhyme) denotes an equation
+
+    lhs_shape and rhs_shape are nested pairs (tuples) of None giving how
+    the operation is nested, and rhyme a tuple of int (starting with 0)
+    giving the rhyme scheme (variable names, as numbers).  For instance,
+    Equation(None, ((None, None), None), (0, 1, 0, 2)) is x=(y*x)*z.
+=end
+
+    attr_reader :lhs_shape, :rhs_shape, :rhyme
+
+    def initialize(lhs_shape, rhs_shape, rhyme)
+        @lhs_shape = lhs_shape
+        @rhs_shape = rhs_shape
+        @rhyme = rhyme
+    end
+
+    # Class Method
+    def self.from_id(eq_id)
+        # Construct an equation from its id
+        _equation_from_id(eq_id)  
+    end
+end
+
+# Recursive approach to mapping from equation number to id and vice-versa
+
+# Counting equations of some order, based on https://oeis.org/A103293, refactored to access intermediate results.
+
+def num_eqs(n, memo = {})
+    # Sequence https://oeis.org/A376640 of the number of magma equations
+    return memo[n] if memo.key?(n)
+
+    result = if n.odd?
+        (MathHelpers.catalan(n + 1) * MathHelpers.bell(n + 2)) / 2
+    else
+        return 2 if n == 0
+        ((MathHelpers.catalan(n + 1) - MathHelpers.catalan(n / 2)) * MathHelpers.bell(n + 2)) / 2 + MathHelpers.catalan(n / 2) * bell_same_shape(n)
+    end
+
+    memo[n] = result
+    result
+end
+
+@bell_same_shape_cache = {}
+def bell_same_shape(n)
+    # Number of rhymes when lhs and rhs have the same (n//2)-operations shape
+    return 2 if n == 0
+    return @bell_same_shape_cache[n] if @bell_same_shape_cache.key?(n)
+
+    sum_stirling = (0..(n + 2)).sum { |k| stirling_sym(n + 2, k) }
+    result = (MathHelpers.bell(n + 2) + sum_stirling - 2 * MathHelpers.bell(1 + n / 2)) / 2
+
+    @bell_same_shape_cache[n] = result
+    result
+end
+
+@stirling_cache = {}
+def stirling_sym(n, k)
+    # Number of symmetric k-partitions of range(n), see https://oeis.org/A103293
+    key = [n, k]
+    return @stirling_cache[key] if @stirling_cache.key?(key)
+
+    if n < 2
+        result = (k == n) ? 1 : 0
+    else
+        result = k * stirling_sym(n - 2, k) + stirling_sym(n - 2, k - 1) + stirling_sym(n - 2, k - 2)
+    end
+
+    @stirling_cache[key] = result
+    result
+end
+
+
+
+# Map from equation to id and back
+
+def _equation_from_id(input_eq)
+  @cache ||= {}
+  return @cache[input_eq] if @cache.key?(input_eq)
+
+  n = 0
+  eq_num = input_eq - 1
+
+  # @cache[input_eq] = result
+  result
+end
+
+
 # Helper fuctions to supplement built in python methods not available in Ruby
 def strip_chars(str, chars)
   pattern = /\A[#{Regexp.escape(chars)}]+|[#{Regexp.escape(chars)}]+\z/
   str.gsub(pattern, '')
+end
+
+module MathHelpers
+  @factorial_cache = {0 => 1, 1 => 1}
+  @binomial_cache = {}
+  @catalan_cache = {}
+  @bell_cache = {0 => 1}
+
+  def self.factorial(n)
+    return @factorial_cache[n] if @factorial_cache.key?(n)
+    @factorial_cache[n] = n * factorial(n - 1)
+  end
+
+  def self.binomial(n, k)
+    return 0 if k > n || k < 0
+    return 1 if k == 0 || k == n
+    key = [n, k]
+    return @binomial_cache[key] if @binomial_cache.key?(key)
+
+    # Pascal's rule: C(n,k) = C(n-1,k-1) + C(n-1,k)
+    @binomial_cache[key] = binomial(n - 1, k - 1) + binomial(n - 1, k)
+  end
+
+  def self.catalan(n)
+    return @catalan_cache[n] if @catalan_cache.key?(n)
+    # C_n = (1 / (n+1)) * C(2n, n)
+    @catalan_cache[n] = binomial(2 * n, n) / (n + 1)
+  end
+
+  def self.bell(n)
+    return @bell_cache[n] if @bell_cache.key?(n)
+    # B_{n+1} = sum_{k=0}^{n} C(n, k) * B_k
+    @bell_cache[n] = (0...n).map { |k| binomial(n - 1, k) * bell(k) }.sum
+  end
 end
 
 # Code used when module is used as a script
@@ -55,7 +178,11 @@ def process_equation(eq_str)
         input_eq = nil
     end
 
-    puts "Processing: #{eq_str}"  # placeholder
+    if input_eq.is_a?(Integer)
+        puts "Processing ID: #{input_eq}"  # placeholder for actual processing
+    else
+        puts "Processing: #{eq_str}"  # placeholder
+    end
 end
 
 def main()

--- a/scripts/generate_graphiti_data.rb
+++ b/scripts/generate_graphiti_data.rb
@@ -1,4 +1,4 @@
-# See .github/workflows/blueprint.yml for proper invocation to generate graphiti data. Then run:
+# See .github/workflows/blueprint-paper.yml for proper invocation to generate graphiti data. Then run:
 # python -m http.server 8000 --directory home_page/graphiti
 
 require 'json'

--- a/scripts/generate_graphiti_data.rb
+++ b/scripts/generate_graphiti_data.rb
@@ -3,6 +3,7 @@
 
 require 'json'
 require File.join(__dir__, 'graph')
+require File.join(__dir__, 'find_equation_id')
 
 if ARGV.length != 5
   $stderr.puts "Usage: scripts/generate_graphiti_data.rb <duals json> <implications json> <unknowns json> <finite implications json> <finite unknowns json>"
@@ -12,13 +13,12 @@ end
 duals = JSON.parse(File.read(ARGV[0]))
 
 equations = {}
-["1_999", "1000_1999", "2000_2999", "3000_3999", "4000_4694"].each { |i|
-  File.read(File.join(__dir__, "../equational_theories/Equations/Eqns#{i}.lean")).split("\n").each { |s|
-    if s =~ /equation\s*(\d+)\s*:=\s*(.+)/
-      equations[$1.to_i] = $2
-    end
-  }
-}
+
+for i in 1..4694
+    eq = Equation.from_id(i)
+    equations[i] = eq.to_s
+end
+
 File.read(File.join(__dir__, '../equational_theories/Equations/Basic.lean')).split("\n").each { |s|
   if s =~ /abbrev Equation(\d+).*: G, (.+)/ || s =~ /equation\s*(\d+)\s*:=\s*(.+)/
     if !equations[$1.to_i]


### PR DESCRIPTION
This pull request:
1.  Ports Bruno's equation numbering code from `find_equation_id.py` to `find_equation_id.rb`, which provides functionality for mapping magma equations to and from their IDs. The script can be used both interactively and with command-line arguments, and it includes a range of mathematical utilities for handling equations.

2. Updates `generate_graphiti_data.rb` to use `find_equation_id.rb` for generating equation list.

Closes #1083