### PR TITLE
Update blueprint-paper.yml

### DIFF
--- a/.github/workflows/blueprint-paper.yml
+++ b/.github/workflows/blueprint-paper.yml
@@ -101,9 +101,9 @@ jobs:
           ./scripts/lean4_checker/run_lean4checker.sh
         shell: bash
 
-      - name: Check with lean4lean
-        run: |
-            python scripts/lean4lean_checker/main.py
+      #- name: Check with lean4lean
+      #  run: |
+      #      python scripts/lean4lean_checker/main.py
 
       - name: Generate graph data
         run: |


### PR DESCRIPTION
temporarily disable lean4lean checker until further debugging w.r.t recent changes to lean4lean. We still have lean4checker in place.