### PR TITLE
chore: Fix grammatical error in acknowledgments section

### DIFF
--- a/paper/conclusions.tex
+++ b/paper/conclusions.tex
@@ -32,4 +32,4 @@ It is possible that the timing in which certain proof methods were introduced in
 \section*{Acknowledgments}
 
 We are grateful to the many additional participants to the Equational Theories Project for their
-numerous comments and encouragement, with particular thanks to  Stanley Burris, Edward van de Meent and David Roberts. Additionally, we note that Shreyas Srinivas is a doctoral students at the Saarbr\"{u}cken Graduate School for Computer Science.
+numerous comments and encouragement, with particular thanks to  Stanley Burris, Edward van de Meent and David Roberts. Additionally, we note that Shreyas Srinivas is a doctoral student at the Saarbr\"{u}cken Graduate School for Computer Science.


### PR DESCRIPTION
This pull request makes a small correction to the acknowledgments section of the paper, fixing a grammatical error.

- Corrected "doctoral students" to "doctoral student" in the acknowledgments section of `paper/conclusions.tex` for improved grammatical accuracy.