### PR TITLE
[ENHANCE]: Add navigation links to frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,11 @@ widget/node_modules/*
 .idea
 equational_theories/Generated/All4x4Tables/src/finite_magma_tools/bin
 equational_theories/Generated/All4x4Tables/src/finite_magma_tools/dist-newstyle
+
+# Ignore changes generated when running the ci locally to work on the equation explorer
+# Specifically folders that are untracked by git.
+home_page/dashboard/
+home_page/raw_data/
+
+# Ignore elm dependencies
+tools/fme/elm-stuff/

--- a/home_page/graphiti/index.html
+++ b/home_page/graphiti/index.html
@@ -274,13 +274,20 @@
       </ul>
 
       <p>
-        Note that all vertices are clickable links to the Equation Explorer,
+        Note that all vertices are clickable links to the <a href="https://teorth.github.io/equational_theories/implications">Equation Explorer</a>,
         with equivalence classes linking to the lowest numbered equivalent.
       </p>
+      <a href="https://teorth.github.io/equational_theories/"
+        >Back to ETP</a
+      >
     </div>
 
     <div id="graph" style="display: none">
       <div class="top-bar">
+        <a href="https://teorth.github.io/equational_theories/"
+        >Back to ETP</a
+        >
+        ◇
         <a href="#" id="search-link" onclick="backToSearch(event)"
           >Back to search</a
         >

--- a/home_page/implications/index.html
+++ b/home_page/implications/index.html
@@ -254,6 +254,7 @@
     <script src="script.js"></script>
 
     <div>
+      <br><a href="https://teorth.github.io/equational_theories/">Back to Equational Theories</a>
       <p>Last updated at: <span id="lastUpdated"></span> (local time), Git commit: <a id="commitLink" target="_blank"></a></p>
     </div>
   </body>

--- a/tools/fme/dist/elm.js
+++ b/tools/fme/dist/elm.js
@@ -5598,6 +5598,7 @@ var $elm$browser$Browser$Document = F2(
 	function (title, body) {
 		return {aU: body, bm: title};
 	});
+var $elm$html$Html$a = _VirtualDom_node('a');
 var $elm$html$Html$Attributes$stringProperty = F2(
 	function (key, string) {
 		return A2(
@@ -5608,6 +5609,12 @@ var $elm$html$Html$Attributes$stringProperty = F2(
 var $elm$html$Html$Attributes$class = $elm$html$Html$Attributes$stringProperty('className');
 var $elm$html$Html$div = _VirtualDom_node('div');
 var $elm$html$Html$h1 = _VirtualDom_node('h1');
+var $elm$html$Html$Attributes$href = function (url) {
+	return A2(
+		$elm$html$Html$Attributes$stringProperty,
+		'href',
+		_VirtualDom_noJavaScriptUri(url));
+};
 var $elm$html$Html$Attributes$id = $elm$html$Html$Attributes$stringProperty('id');
 var $elm$virtual_dom$VirtualDom$text = _VirtualDom_text;
 var $elm$html$Html$text = $elm$virtual_dom$VirtualDom$text;
@@ -5718,7 +5725,6 @@ var $author$project$Main$viewLeftPanel = function (model) {
 };
 var $elm$html$Html$p = _VirtualDom_node('p');
 var $elm$html$Html$pre = _VirtualDom_node('pre');
-var $elm$html$Html$a = _VirtualDom_node('a');
 var $elm$core$String$filter = _String_filter;
 var $author$project$Main$graphitiEq = function (_v0) {
 	var a = _v0.a;
@@ -5729,12 +5735,6 @@ var $author$project$Main$graphitiLink = function (tags) {
 		$elm$core$String$join,
 		'+',
 		A2($elm$core$List$map, $author$project$Main$graphitiEq, tags));
-};
-var $elm$html$Html$Attributes$href = function (url) {
-	return A2(
-		$elm$html$Html$Attributes$stringProperty,
-		'href',
-		_VirtualDom_noJavaScriptUri(url));
 };
 var $author$project$Main$matchInput = F2(
 	function (matcher, tag) {
@@ -6058,7 +6058,7 @@ var $author$project$Main$viewExportNovel = F3(
 											_Utils_ap(tableLine, prov))
 										]))
 								])),
-							$elm$html$Html$text('Finally, re-run `python3 equational_theories/Generated/All4x4Tables/src/generate_lean.py`!')
+							$elm$html$Html$text('Finally, re-run `python3 equational_theories/Generated/FinSearch/src/generate_lean.py`!')
 						]));
 			}
 		}
@@ -6304,6 +6304,44 @@ var $author$project$Main$view = function (model) {
 					[
 						$author$project$Main$viewLeftPanel(model),
 						$author$project$Main$viewRightPanel(model)
+					])),
+				A2(
+				$elm$html$Html$div,
+				_List_fromArray(
+					[
+						$elm$html$Html$Attributes$class('back-to-eqt')
+					]),
+				_List_fromArray(
+					[
+						A2(
+						$elm$html$Html$a,
+						_List_fromArray(
+							[
+								$elm$html$Html$Attributes$href('https://teorth.github.io/equational_theories')
+							]),
+						_List_fromArray(
+							[
+								$elm$html$Html$text('Back to Equational Theories')
+							]))
+					])),
+				A2(
+				$elm$html$Html$div,
+				_List_fromArray(
+					[
+						$elm$html$Html$Attributes$class('back-to-exp')
+					]),
+				_List_fromArray(
+					[
+						A2(
+						$elm$html$Html$a,
+						_List_fromArray(
+							[
+								$elm$html$Html$Attributes$href('https://teorth.github.io/equational_theories/implications')
+							]),
+						_List_fromArray(
+							[
+								$elm$html$Html$text('Back to Equation Explorer')
+							]))
 					])),
 				A2(
 				$elm$html$Html$div,

--- a/tools/fme/src/Main.elm
+++ b/tools/fme/src/Main.elm
@@ -289,6 +289,12 @@ view model =
       [ viewLeftPanel model
       , viewRightPanel model
       ]
+    , div [class "back-to-eqt"]
+    [a [ href "https://teorth.github.io/equational_theories" ]
+        [ text "Back to Equational Theories" ]]
+    , div [class "back-to-exp"]
+    [a [ href "https://teorth.github.io/equational_theories/implications" ]
+        [ text "Back to Equation Explorer" ]]
     , div [class "copyright"]
       [text ("© 2024 The Equational Theories Project / data: " ++ String.left 7 model.version)]
     ]


### PR DESCRIPTION
This pr was broken up from #1288 
- Link from equation explorer to frontend home page.
- Link from finite magma explorer to frontend home page and equation explorer.
- Link from graphiti to frontend home page and equation explorer.
- Ignore local files.

[Link to thread on Zulip](https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/.23848/with/553945753)