### PR TITLE
[FIX] Add target attribute to links for opening in new tab

### DIFF
--- a/tools/fme/dist/elm.js
+++ b/tools/fme/dist/elm.js
@@ -5520,11 +5520,17 @@ var $author$project$Main$update = F2(
 					var urlRequest = msg.a;
 					if (!urlRequest.$) {
 						var url = urlRequest.a;
-						return _Utils_Tuple2(
+						return A2(
+							$elm$core$String$startsWith,
+							'/equational_theories/fme/',
+							$elm$url$Url$toString(url)) ? _Utils_Tuple2(
 							model,
 							A2(
 								$elm$browser$Browser$Navigation$pushUrl,
 								model.M,
+								$elm$url$Url$toString(url))) : _Utils_Tuple2(
+							model,
+							$elm$browser$Browser$Navigation$load(
 								$elm$url$Url$toString(url)));
 					} else {
 						var href = urlRequest.a;
@@ -5616,7 +5622,6 @@ var $elm$html$Html$Attributes$href = function (url) {
 		_VirtualDom_noJavaScriptUri(url));
 };
 var $elm$html$Html$Attributes$id = $elm$html$Html$Attributes$stringProperty('id');
-var $elm$html$Html$Attributes$target = $elm$html$Html$Attributes$stringProperty('target');
 var $elm$virtual_dom$VirtualDom$text = _VirtualDom_text;
 var $elm$html$Html$text = $elm$virtual_dom$VirtualDom$text;
 var $author$project$Main$ClickProcessBtn = {$: 5};
@@ -5754,6 +5759,7 @@ var $author$project$Main$matchInput = F2(
 				},
 				eqn));
 	});
+var $elm$html$Html$Attributes$target = $elm$html$Html$Attributes$stringProperty('target');
 var $elm$html$Html$ul = _VirtualDom_node('ul');
 var $author$project$Main$ExploreEquation = function (a) {
 	return {$: 6, a: a};
@@ -6058,7 +6064,7 @@ var $author$project$Main$viewExportNovel = F3(
 											_Utils_ap(tableLine, prov))
 										]))
 								])),
-							$elm$html$Html$text('Finally, re-run `python3 equational_theories/Generated/FinSearch/src/generate_lean.py`!')
+							$elm$html$Html$text('Finally, re-run `python3 equational_theories/Generated/All4x4Tables/src/generate_lean.py`!')
 						]));
 			}
 		}
@@ -6317,8 +6323,7 @@ var $author$project$Main$view = function (model) {
 						$elm$html$Html$a,
 						_List_fromArray(
 							[
-								$elm$html$Html$Attributes$href('https://teorth.github.io/equational_theories'),
-								$elm$html$Html$Attributes$target('_blank')
+								$elm$html$Html$Attributes$href('https://teorth.github.io/equational_theories')
 							]),
 						_List_fromArray(
 							[
@@ -6337,8 +6342,7 @@ var $author$project$Main$view = function (model) {
 						$elm$html$Html$a,
 						_List_fromArray(
 							[
-								$elm$html$Html$Attributes$href('https://teorth.github.io/equational_theories/implications'),
-								$elm$html$Html$Attributes$target('_blank')
+								$elm$html$Html$Attributes$href('https://teorth.github.io/equational_theories/implications')
 							]),
 						_List_fromArray(
 							[

--- a/tools/fme/src/Main.elm
+++ b/tools/fme/src/Main.elm
@@ -69,7 +69,10 @@ update msg model =
     UrlRequested urlRequest ->
       case urlRequest of
         Browser.Internal url ->
-          (model, Browser.Navigation.pushUrl model.key (Url.toString url))
+          if String.startsWith "/equational_theories/fme/" (Url.toString url) then
+            ( model, Browser.Navigation.pushUrl model.key (Url.toString url) )
+          else
+            ( model, Browser.Navigation.load (Url.toString url) )
         Browser.External href ->
           (model, Browser.Navigation.load href)
 
@@ -290,10 +293,10 @@ view model =
       , viewRightPanel model
       ]
     , div [class "back-to-eqt"]
-    [a [ href "https://teorth.github.io/equational_theories", target "_blank" ]
+    [a [ href "https://teorth.github.io/equational_theories" ]
         [ text "Back to Equational Theories" ]]
     , div [class "back-to-exp"]
-    [a [ href "https://teorth.github.io/equational_theories/implications", target "_blank" ]
+    [a [ href "https://teorth.github.io/equational_theories/implications" ]
         [ text "Back to Equation Explorer" ]]
     , div [class "copyright"]
       [text ("© 2024 The Equational Theories Project / data: " ++ String.left 7 model.version)]


### PR DESCRIPTION
Clicking on the link just change the url instead of taking one to the new page, this update makes the browser open up the link in a new tab so it should work fine.

[Link to thread on Zulip](https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/.23848/with/553945753)