### PR TITLE
[PAPER] Update Harald Husum affiliation to Intelecy

### DIFF
--- a/paper/contributions.tex
+++ b/paper/contributions.tex
@@ -13,7 +13,7 @@ In a \href{https://github.com/teorth/equational_theories/blob/main/paper/contrib
     \item Martin Dvorak: Institute of Science and Technology Austria, martin.dvorak@matfyz.cz
     \item Andr\'es Goens: TU Darmstadt, andres.goens@tu-darmstadt.de
     \item Aaron Hill: Unaffiliated, aa1ronham@gmail.com
-    \item Harald Husum: Unaffiliated, harald.husum@gmail.com
+    \item Harald Husum: Intelecy, harald.husum@intelecy.com
     \item Hern\'an Ibarra Mejia:  Unaffiliated, hernan@ibarramejia.com
     \item Zoltan A. Kocsis: University of New South Wales, z.kocsis@unsw.edu.au
     \item Bruno Le Floch: CNRS and Laboratoire de Physique Th\'eorique et Hautes \'Energies, Sorbonne Universit\'e, blefloch@lpthe.jussieu.fr, ORCID 0000-0002-3965-9705


### PR DESCRIPTION
  - Updates the contributions list to reflect my Intelecy affiliation.
  - Switches my contact email to harald.husum@intelecy.com.
  
  I’ve used employer-provided hardware for this project, so I figure the affiliation should be recognized.