### PR TITLE
Enlarge the Equation Explorer figure, avoid bad page breaks

### DIFF
--- a/paper/GUI.tex
+++ b/paper/GUI.tex
@@ -6,12 +6,12 @@ A number of custom web applications were developed as part of the ETP. While man
   \item The \textbf{ETP dashboard}\footnote{\url{https://teorth.github.io/equational_theories/dashboard/}} displays the high-level overview of the project: the total number of resolved, conjectured, and unknown implications for the general and finite implication graphs. The dashboard also includes links to other tools, data, and visualizations about the implication graphs.
   \item The \textbf{Equation Explorer}\footnote{\url{https://teorth.github.io/equational_theories/implications/}} is the primary tool to navigate the implication graph. For a given equation, it displays its inbound and outbound implications, as well as other members of its equivalence class. The explorer allows navigating either the general or finite implication graphs. The explorer also features custom commentary for a given equation (when available), serving as a repository for information and links. It also links to Graphiti visualizations and an example of its smallest satisfying magma, if one exists. \Cref{fig:screenshot-equation-explorer} shows an example view of the explorer.
   \item \textbf{Graphiti}\footnote{\url{https://teorth.github.io/equational_theories/graphiti/}} visualizes the implication graph as a Hasse diagram, where downward edges represent subset relationships, and upward edges represent implications. Equivalence classes are collapsed into single nodes for clarity. Graphiti supports search parameters to visualize specific subsets of the graph. It can also display the entire implication graph, though the complete graph is large and challenging to navigate. \Cref{fig:854-like} is an example of a Graphiti visualization.
-  \item The \textbf{Finite Magma Explorer}\footnote{\url{https://teorth.github.io/equational_theories/fme/}} tests which equations a given finite magma satisfies or fails to satisfy. Users input finite magmas as Cayley tables. The tool is aware of the finite implication graph, so if an input magma witnesses an unknown refutation, it notifies the user and provides instructions for contributing the result to the GitHub repository.
+  \item The \textbf{Finite Magma Explorer}\footnote{\url{https://teorth.github.io/equational_theories/fme/}} tests which equations a given finite magma satisfies or fails to satisfy. Users input finite magmas as Cayley tables. The tool is aware of the finite implication graph, so if an input magma witnesses an unknown refutation, it notifies the user and provides instructions for contributing it to the GitHub repository.
 \end{enumerate}
 
-\begin{figure}[b]
+\begin{figure}
   \centering
-  \includegraphics[width=0.85\textwidth]{GUI-equation-explorer.png}
+  \includegraphics[width=1.0\textwidth]{GUI-equation-explorer.png}
   \caption{An example of the information displayed by the Equation Explorer for a specific equation.}
   \label{fig:screenshot-equation-explorer}
 \end{figure}

--- a/paper/main.tex
+++ b/paper/main.tex
@@ -122,6 +122,7 @@
 
 \appendix
 \crefalias{section}{appendix}
+\raggedbottom
 \input{numbering}
 \input{contributions}
 

--- a/paper/numbering.tex
+++ b/paper/numbering.tex
@@ -47,7 +47,6 @@ $$ 1, 1, 2, 4, 11, 32, 117, \dots$$
 (\url{https://oeis.org/A103293}).  A proof of this claim can be found in the ETP blueprint.  In particular, there are $4694$ equations of order at most $4$.
 
 Below we record some specific equations appearing in this paper, using the alphabet $\x$, $\y$, $\z$, $\w$ in place of $0$, $1$, $2$, $3$ for readability.
-
 \begingroup\allowdisplaybreaks
 \begin{align}
     \x &\formaleq \x & \hbox{(Trivial law)} \label{eq1}\tag{E1} \\

--- a/paper/references.bib
+++ b/paper/references.bib
@@ -28,7 +28,7 @@
 }
 
 @article{Kisielewicz2,
-  author     = {Kisielewicz, A.},
+  author     = {Kisielewicz, Andrzej},
   title      = {Austin identities},
   journal    = {Algebra Universalis},
   fjournal   = {Algebra Universalis},


### PR DESCRIPTION
This should only be merged after Osalotioman's PR #1402 It makes sure that page breaks stay reasonable despite the height change of Figure 16.  For the appendices I added \raggedbottom, which has a very minor effect since the appendices contain almost no flexible spaces.  The main effect is to get rid of warnings. I also added Kisielewicz's first name to a reference to reduce an underfull hbox's badness.