### PR TITLE
fix: emit dual of each proven implication in extract_implications

### DIFF
--- a/scripts/extract_implications.lean
+++ b/scripts/extract_implications.lean
@@ -154,7 +154,12 @@ def generateOutput (inp : Cli.Parsed) : IO UInt32 := do
     let rs := matchFinite rs finite_only
     let rs := if only_implications then rs.filter (·.variant matches .implication ..) else rs
     let rs := rs.map (·.variant)
-    let rs ← if include_impl then Closure.closure rs dualityRelation.dualEquations else pure (Closure.toEdges rs)
+    let rs ← if include_impl then Closure.closure rs dualityRelation.dualEquations else do
+      let edges := Closure.toEdges rs
+      let duals := edges.filterMap fun
+        | .implication imp => (dualityRelation.dual imp).map (.implication ·)
+        | _ => none
+      pure (edges ++ duals)
     if inp.hasFlag "json" then
       let implications := (rs.filter (·.isTrue)).map (·.get)
       let nonimplications := (rs.filter (!·.isTrue)).map (·.get)


### PR DESCRIPTION
## Summary

When `lake exe extract_implications` lists proven implications (without `--closure`), it only printed edges extracted directly from Lean theorems. If `Equation1113 → Equation2534` is proven and 1113/2534 are dual laws, the dual implication `Equation2534 → Equation1113` was missing even though it follows by magma duality.

## Root cause

`generateOutput` called `Closure.toEdges` alone in the non-closure path. Dualization is wired into `closure_aux`, but that path is only used with `--closure`.

## Why this fix is correct

For each direct implication edge, we also append its dual (via `DualityRelation.dual`). Proving `A → B` yields the dual proof `dual(A) → dual(B)`; when `A` and `B` are dual pairs this is the reverse implication the reporter expected under `--finite-only`.

Fixes #1245

## Test plan
- [ ] `lake build`
- [ ] `lake exe extract_implications --finite-only | grep '^Equation1113'` shows both directions when the finite implication is proven