### PR TITLE
fix: add permalink to Equation677 finite-implication Zulip link

### DIFF
--- a/commentary/Equation677.md
+++ b/commentary/Equation677.md
@@ -2,7 +2,7 @@
 
 See [this chapter of the blueprint](https://teorth.github.io/equational_theories/blueprint/677-chapter.html).
 
-This equation is the last one to resist analysis for either the infinite or finite magma part of the project.  The implication to [Equation 255](https://teorth.github.io/equational_theories/implications/?255&finite) for finite models remains open, and is discussed [here](https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/FINITE.3A.20677.20-.3E.20255).  It is immune to linear models and the cohomological approach.  On the other hand, 255 would follow from right cancellability, and even from the existence, for all `x`, of an element `y` such that `y ◇ x = x`.
+This equation is the last one to resist analysis for either the infinite or finite magma part of the project.  The implication to [Equation 255](https://teorth.github.io/equational_theories/implications/?255&finite) for finite models remains open, and is discussed [here](https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/FINITE.3A.20677.20-.3E.20255/near/486373274).  It is immune to linear models and the cohomological approach.  On the other hand, 255 would follow from right cancellability, and even from the existence, for all `x`, of an element `y` such that `y ◇ x = x`.
 
 This law implies that left multiplications are surjective.  For finite magmas they are thus bijective.  This law cannot hold in a non-trivial semigroup (associative magma).
 


### PR DESCRIPTION
## Summary
Adds a message anchor to the topic-only Zulip link in `commentary/Equation677.md`.

## Bug
Issue #549 reported that topic-only Zulip URLs break when a topic is renamed. PR #554 fixed many such links, but this commentary entry still ended at `/topic/FINITE.3A.20677.20-.3E.20255`.

## Root cause
Links ending in `/topic/NAME` are not permalinks; only `/topic/NAME/near/ID` survives topic renames.

## Why this fix is correct
Message `486373274` is the first post in the "FINITE: 677 -> 255" thread (verified via the Lean Zulip archive), matching the permalink convention from #554.

## Test plan
- [x] Verified diff is a single URL change in one file


Made with [Cursor](https://cursor.com)