### PR TITLE
fix: add permalink to Dupont/Dupond target Zulip link

### DIFF
--- a/commentary/Equation63.md
+++ b/commentary/Equation63.md
@@ -1,6 +1,6 @@
 ## The "Dupont" equation
 
-Closely related to the ["Dupond" equation, 1692](https://teorth.github.io/equational_theories/implications/?1692).  In particular, the two equations are equivalent for finite magmas, or for quasigroups, but [neither implies the other for infinite ones](https://teorth.github.io/equational_theories/blueprint/infinite-magma-constructions-chapter.html#dupont-section).  See [this discussion](https://leanprover.zulipchat.com/#narrow/stream/458659-Equational/topic/Proposed.20new.20target.3A.2063.20and.201692.20.28.22Dupont.20and.20Dupond.22.29).
+Closely related to the ["Dupond" equation, 1692](https://teorth.github.io/equational_theories/implications/?1692).  In particular, the two equations are equivalent for finite magmas, or for quasigroups, but [neither implies the other for infinite ones](https://teorth.github.io/equational_theories/blueprint/infinite-magma-constructions-chapter.html#dupont-section).  See [this discussion](https://leanprover.zulipchat.com/#narrow/stream/458659-Equational/topic/Proposed.20new.20target.3A.2063.20and.201692.20.28.22Dupont.20and.20Dupond.22.29/near/477121484).
 
 This pair shares many similarities with the "Asterix" ([equation 65](https://teorth.github.io/equational_theories/implications/?65)) and "Obelix" ([equation 1491](https://teorth.github.io/equational_theories/implications/?1491)) pair.
 


### PR DESCRIPTION
## Summary
Adds a message anchor to the topic-only Zulip link in `commentary/Equation63.md`.

## Bug
Issue #549 reported that topic-only Zulip URLs break when a topic is renamed. PR #554 fixed many such links, but the Dupont/Dupond discussion link in this commentary file still ended at the topic slug only.

## Root cause
Links ending in `/topic/NAME` are not permalinks; only `/topic/NAME/near/ID` survives topic renames.

## Why this fix is correct
Message `477121484` is the first post in the "Proposed new target: 63 and 1692 (Dupont and Dupond)" thread (verified via the Lean Zulip archive), matching the permalink convention from #554.

## Test plan
- [x] Verified diff is a single URL change in one file


Made with [Cursor](https://cursor.com)