### PR TITLE
fix: return id 0 for tautological equations in JS canonicalizer

### DIFF
--- a/home_page/implications/find_equation_id.js
+++ b/home_page/implications/find_equation_id.js
@@ -599,6 +599,11 @@ function _equationId(inputEq) {
     if (l !== r) {
         pid = findRhymeId(inputEq.rhyme);
     } else {
+        const sliceIndex = Number(nLhs + 1n);
+        const rotated = [...inputEq.rhyme.slice(sliceIndex), ...inputEq.rhyme.slice(0, sliceIndex)];
+        if (arrayEqual(inputEq.rhyme, rotated) && n > 0n) {
+            return 0n;
+        }
         // Slow code here
         pid = 0n;
         for (const rhyme of allRhymes(n + 1n)) {


### PR DESCRIPTION
## Summary
- `_equationId` in `find_equation_id.js` could assign a nonzero id to tautological equations such as `x*(y*x)=x*(y*x)`.

## Root cause
#1427 fixed this in `find_equation_id.py` by returning `0` when the rhyme equals its lhs/rhs rotation, but the JS port still counted such rhymes in the slow balanced branch.

## Fix
Mirror the Python early return before the rhyme enumeration loop.

## Test plan
- [ ] `Equation.fromStr('x*(y*x)=x*(y*x)').id === 0n` in the browser helper


Made with [Cursor](https://cursor.com)