### PR TITLE
fix: add missing line break in iteration lemma align block

### DIFF
--- a/blueprint/src/chapter/infinite_magma_constructions.tex
+++ b/blueprint/src/chapter/infinite_magma_constructions.tex
@@ -135,7 +135,7 @@ Clearly we still have nested finite sets $E'_0 \subseteq E'_1 \subseteq E'_2$.
 \item Extend $f : E_1 \to E_2$ to a function $f': E'_1 \to E'_2$ by defining
 \begin{align*}
   f'(h_1) &:= h_2 \\
-  f'(h_0+h_1+h_2) &:= -h_1-h_2
+  f'(h_0+h_1+h_2) &:= -h_1-h_2 \\
   f'(h_2) &:= h_3 \\
   f'(h_1+h_2+h_3) &:= -h_2-h_3
 \end{align*}


### PR DESCRIPTION
## Summary

In the third case of Lemma `\ref{iteration}`, the `align*` block defining $f'$ was missing `\\` after `f'(h_0+h_1+h_2) := -h_1-h_2`.

## Root cause

Without the line break, the blueprint renders `-h_1-h_2 f'(h_2) := h_3` on one line instead of two separate definitions.

## Fix

Add the missing `\\`.

Related to #470

Made with [Cursor](https://cursor.com)