### PR TITLE
fix: add Zulip permalinks for Obelix and Littlewood commentary

### DIFF
--- a/commentary/Equation1086.md
+++ b/commentary/Equation1086.md
@@ -3,6 +3,6 @@
 In finite magmas, or in quasigroups, the Littlewood law 2541 (dual of 1086) is equivalent to the
 [Ramanujan law 1729](https://teorth.github.io/equational_theories/implications/?1729) and [Hardy law 917](https://teorth.github.io/equational_theories/implications/?917).  Without such assumptions, the Ramanujan law 1729 implies the Littlewood law 2541, but no other implication holds.  For translation-invariant models, the Ramanujan law implies the Hardy law.
 
-Discussed [here](https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/Outstanding.20equations.2C.20v1).  The Littlewood law is confluent and implies that right multiplications are surjective.
+Discussed [here](https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/Outstanding.20equations.2C.20v1/near/477833464).  The Littlewood law is confluent and implies that right multiplications are surjective.
 
 The laws 1729, 917, 2541 are twists of laws [125](https://teorth.github.io/equational_theories/implications/?125), [73](https://teorth.github.io/equational_theories/implications/?73), [229](https://teorth.github.io/equational_theories/implications/?229) by the squaring map.

--- a/commentary/Equation1491.md
+++ b/commentary/Equation1491.md
@@ -2,7 +2,7 @@
 
 Closely related to the ["Asterix" equation, 65](https://teorth.github.io/equational_theories/implications/?65).  In particular, the "Asterix" and "Obelix" equations are equivalent for finite magmas or for quasigroups, but neither implies the other for [infinite ones](https://teorth.github.io/equational_theories/blueprint/infinite-magma-constructions-chapter.html#asterix-section).
 
-A greedy translation-invariant construction of Obelix magmas is [given here](https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/Obelix.3A.20joining.20two.20approaches).
+A greedy translation-invariant construction of Obelix magmas is [given here](https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/Obelix.3A.20joining.20two.20approaches/near/476555584).
 
 The free magma with one generator for this law is isomorphic to `ℤ/3ℤ` equipped with `x◇y = y+1`.  In particular, in any magma the squaring map `S: x ↦ x◇x` and cubing maps `B: x ↦ x◇(x◇x)` and `C: x ↦ (x◇x)◇x` are bijections of order 3 with `S(x) = C(x)` and `B(x) = S(S(x))` and `S(S(S(x))) = x`.
 


### PR DESCRIPTION
## Summary
- Add `/near/` permalinks to the Obelix construction link in `Equation1491.md`.
- Add `/near/` permalink to the Outstanding equations thread link in `Equation1086.md`.

## Test plan
- [ ] Click both commentary links and confirm they land on the intended Zulip messages.


Made with [Cursor](https://cursor.com)