### PR TITLE
blueprint: fix operator symbol in equation-ordering example

### DIFF
--- a/blueprint/src/chapter/intro.tex
+++ b/blueprint/src/chapter/intro.tex
@@ -222,7 +222,7 @@ For instance, $\ast \op \ast \formaleq \ast \op (\ast \op \ast)$ is less than $\
 Finally, we order (and reduce) equations of the form $w \formaleq w'$ as follows. Define the \emph{shape} of an equation to be the equation in which all variables are replaced by placeholders $\ast$.
 \begin{itemize}
   \item (i) Equations of lower shape will be of lower order.  For instance, any equation of shape $\ast \op \ast \formaleq \ast \op (\ast \op \ast)$ is less than any equation $\ast \op \ast \formaleq (\ast \op \ast) \op \ast$.
-  \item (ii) Among equations of equations of equal shape, equations whose variables are first in the lexicographical ordering will be lower. For instance, $0 \ast 0 \formaleq 0 \op (0 \op 0)$ is less than $0 \ast 0 \formaleq 1 \op (1 \op 1)$, which is in turn less than $0 \ast 1 \formaleq 0 \op (0 \op 0)$.
+  \item (ii) Among equations of equal shape, equations whose variables are first in the lexicographical ordering will be lower. For instance, $0 \op 0 \formaleq 0 \op (0 \op 0)$ is less than $0 \op 0 \formaleq 1 \op (1 \op 1)$, which is in turn less than $0 \op 1 \formaleq 0 \op (0 \op 0)$.
   \item (iii) Only the arrangement of the equation (up to relabeling and symmetry) which is minimal in this ordering is retained in the list.  For instance, we do not retain $1 \op 2 \formaleq 1$ because it can be replaced by $0 \formaleq 0 \op 1$, which is earlier in the ordering.
 \item (iv) Any trivial equation $w \formaleq w$, other than the order zero law $0 \formaleq 0$, is discarded.
 \end{itemize}


### PR DESCRIPTION
In the equation-ordering rules (\Cref{basic-theory-chapter}, item (ii)), the example writes the left-hand sides using the placeholder symbol `\ast` instead of the operator `\op`:
`$0 \ast 0 \formaleq \dots$`, `$0 \ast 1 \formaleq \dots$`.

Here `\ast` is the variable placeholder (as in `\ast \op (\ast \op \ast)`), so these should use the magma operation `\op`: `0 \op 0` and `0 \op 1`.

Also drops a duplicated word ("equations of equations of equal shape" -> "equations of equal shape").

Made with [Cursor](https://cursor.com)