### PR TITLE
Prove Law43 term definability from swapped arguments

### DIFF
--- a/equational_theories/Definability/Law43.lean
+++ b/equational_theories/Definability/Law43.lean
@@ -1,5 +1,6 @@
 import Batteries.Data.List.Basic
 import equational_theories.Definability.Basic
+import equational_theories.Definability.Simple
 import equational_theories.Equations.All
 
 open FirstOrder.Language
@@ -9,10 +10,55 @@ open Law.MagmaLaw
 --TODO: the commutative law is definable from anything of the form f(x,y) ≃ f(y,x).
 theorem Equation43_termDefinableFrom_swapped_args {L : NatMagmaLaw}
     (hL2args : ∀ e ∈ L.lhs.elems.1, e ∈ [0,1] := by decide +kernel)
-    (hR2args : ∀ e ∈ L.rhs.elems.1, e ∈ [0,1] := by decide +kernel)
+    (_hR2args : ∀ e ∈ L.rhs.elems.1, e ∈ [0,1] := by decide +kernel)
     (hSymm : L.lhs ⬝ (fun x ↦ Lf $ Equiv.swap 0 1 x) = L.rhs := by rfl)
     : Law43.TermDefinableFrom L := by
-  sorry
+  intro G M hSat
+  letI := M
+  have eval_eq_on_mem :
+      ∀ (t : FreeMagma ℕ) (f g : ℕ → G),
+        (∀ a, t.Mem a → f a = g a) → t ⬝ f = t ⬝ g := by
+    intro t
+    induction t with
+    | Leaf a =>
+        intro f g h
+        exact h a rfl
+    | Fork l r ihl ihr =>
+        intro f g h
+        change (l ⬝ f) ◇ (r ⬝ f) = (l ⬝ g) ◇ (r ⬝ g)
+        rw [ihl f g (fun a ha ↦ h a (.inl ha)),
+            ihr f g (fun a ha ↦ h a (.inr ha))]
+  refine ⟨⟨fun x y ↦ L.lhs ⬝ fun n ↦ if n = 0 then x else y⟩, ?sat, ?defn⟩
+  · intro φ
+    dsimp [satisfiesPhi, Law43]
+    have h := hSat (fun n ↦ if n = 0 then φ 0 else φ 1)
+    dsimp [satisfiesPhi] at h
+    calc
+      L.lhs ⬝ (fun n ↦ if n = 0 then φ 0 else φ 1)
+          = L.rhs ⬝ (fun n ↦ if n = 0 then φ 0 else φ 1) := h
+      _ = (L.lhs ⬝ (fun x ↦ Lf ((Equiv.swap 0 1) x))) ⬝
+            (fun n ↦ if n = 0 then φ 0 else φ 1) := by rw [hSymm]
+      _ = L.lhs ⬝ (fun n ↦ if n = 0 then φ 1 else φ 0) := by
+        rw [FreeMagma.SubstEval]
+        apply eval_eq_on_mem
+        intro a ha
+        have haList : a ∈ L.lhs.elems.1 := (L.lhs.elems.2.2 a).2 ha
+        have ha01 := hL2args a haList
+        simp at ha01
+        rcases ha01 with rfl | rfl <;> simp [FreeMagma.evalInMagma]
+  · let _ := M.FOStructure
+    exact ⟨
+      (MagmaLanguage.lhomWithConstants (∅ : Set G)).onTerm
+        (L.lhs.toTerm.subst fun n ↦
+          if n = 0 then FirstOrder.Language.Term.var 0 else FirstOrder.Language.Term.var 1),
+      by
+        funext v
+        simp [Term.realize_subst, FreeMagma.toTerm_realize]
+        apply eval_eq_on_mem
+        intro a ha
+        by_cases ha0 : a = 0
+        · simp [ha0]
+        · simp [ha0]⟩
 
 /-- The commutative law 43 `x ◇ y = y ◇ x` is TermDefinable from 40 `x ◇ x = y ◇ y`. -/
 theorem Equation43_termDefinableFrom_Equation40 : Law43.TermDefinableFrom Law40 :=


### PR DESCRIPTION
This PR replaces the remaining sorry in `equational_theories/Definability/Law43.lean` for `Equation43_termDefinableFrom_swapped_args`.

The proof constructs the derived magma operation by evaluating `L.lhs` on the two arguments, uses `hSymm` and `FreeMagma.SubstEval` to establish commutativity, and supplies the corresponding term-definability witness via `Term.realize_subst` and `FreeMagma.toTerm_realize`.

Locally verified with:

```
lake build equational_theories.Definability.Law43
```

Result: build completed successfully.