### PR TITLE
fix: remove duplicated words in blueprint chapters

### DIFF
--- a/blueprint/src/chapter/implications.tex
+++ b/blueprint/src/chapter/implications.tex
@@ -1,6 +1,6 @@
 \chapter{Implications between selected laws}\label{implications-chapter}
 
-We collect here some notable implications between the the selected laws in \Cref{subgraph-eq}.   By \Cref{sound-complete}, every implication can basically be established by a finite number of rewrites.  In most cases, the sequence of rewrites is quite straightforward, and the implication is very easy, but we record some less obvious examples.
+We collect here some notable implications between the selected laws in \Cref{subgraph-eq}.   By \Cref{sound-complete}, every implication can basically be established by a finite number of rewrites.  In most cases, the sequence of rewrites is quite straightforward, and the implication is very easy, but we record some less obvious examples.
 
 \begin{theorem}[387 implies 43]\label{387_implies_43}\uses{eq387,eq43}\lean{Subgraph.Equation387_implies_Equation43}\leanok  \Equareffull{387} implies \Equareffull{43}.
 \end{theorem}

--- a/blueprint/src/chapter/rewriting.tex
+++ b/blueprint/src/chapter/rewriting.tex
@@ -91,6 +91,6 @@ Note that, in the above setting, $t\leftarrow l_1\sigma\rightarrow u$, giving us
   Given a rewrite system $R$, if for every critical pair $(t, u)$ of $R$, there is a term $v$ such that $t\rightarrow^* v\ {}^*\leftarrow u$, then $R$ is locally confluent.
 \end{theorem}
 
-Note that building critical pairs of a finite system is computable. Therefore the only step of the completion process which require genuine creativity is the choice of the orientation of the equations, along with the proof that that orientation is strongly normalizing.
+Note that building critical pairs of a finite system is computable. Therefore the only step of the completion process which require genuine creativity is the choice of the orientation of the equations, along with the proof that the orientation is strongly normalizing.
 
 As a capper to this section we can note that even in the event that such an orientation is not found, one can still partially apply the completion procedure, using any well-founded order on terms that is stable by substitution and congruence, to obtain a semi-decision procedure for equality. This process is sometimes called \emph{unfailing completion} and is at the core of the \emph{superposition calculus} used in Vampire.


### PR DESCRIPTION
## Summary
- `implications.tex`: "between the the selected" → "between the selected"
- `rewriting.tex`: "proof that that orientation" → "proof that the orientation"

## Test plan
- [ ] Blueprint compiles (`print.tex`)

Made with [Cursor](https://cursor.com)