### PR TITLE
fix: correct Equatio321577 typo in Sheffer conjecture name

### DIFF
--- a/equational_theories/Sheffer.lean
+++ b/equational_theories/Sheffer.lean
@@ -189,7 +189,7 @@ conjecture Equation321577_implies_Equation329857 (G: Type*) [Magma G] (_ : Equat
 conjecture Equation321577_implies_Equation345169 (G: Type*) [Magma G] (_ : Equation321577 G) : Equation345169 G
 
 @[equational_result]
-conjecture Equatio321577_implies_Equation361729 (G: Type*) [Magma G] (_ : Equation321577 G) : Equation361729 G
+conjecture Equation321577_implies_Equation361729 (G: Type*) [Magma G] (_ : Equation321577 G) : Equation361729 G
 
 @[equational_result]
 conjecture Equation329857_implies_Equation321577 (G: Type*) [Magma G] (_ : Equation329857 G) : Equation321577 G


### PR DESCRIPTION
## Summary
- One of the six Sheffer order-6 equivalence conjectures was declared as `Equatio321577_implies_Equation361729` (missing `n`).
- Renamed to `Equation321577_implies_Equation361729` to match the surrounding declarations.

Independent of #1465. No other references to the misspelled name.

## Test plan
- [ ] Confirm the other five implications already use `Equation321577_...`
- [ ] Grep shows no remaining `Equatio321577`


Made with [Cursor](https://cursor.com)