### PR TITLE
Fill sorry in Law46.lean

### DIFF
--- a/equational_theories/Definability/Law46.lean
+++ b/equational_theories/Definability/Law46.lean
@@ -1,10 +1,20 @@
 import Batteries.Data.List.Basic
 import equational_theories.Definability.Basic
+import equational_theories.Definability.Simple
 import equational_theories.Equations.All
 
 open FirstOrder.Language
 open Law
 open Law.MagmaLaw
+
+/-- Evaluating a `FreeMagma` expression only depends on the values assigned to the variables that
+actually occur in it. -/
+theorem FreeMagma.evalInMagma_congr {α G} [Magma G] {φ ψ : α → G} :
+    ∀ (m : FreeMagma α), (∀ a, m.Mem a → φ a = ψ a) → m ⬝ φ = m ⬝ ψ
+  | Lf _, h => h _ rfl
+  | m₁ ⋆ m₂, h =>
+    congrArg₂ Magma.op (evalInMagma_congr m₁ fun _ ha ↦ h _ (.inl ha))
+      (evalInMagma_congr m₂ fun _ ha ↦ h _ (.inr ha))
 
 /-- The constant law 46 `x ◇ y = z ◇ w` is TermDefinable from any law `lhs = rhs`, where
 lhs and rhs are the same shape, but with disjoint sets of variables. -/
@@ -12,46 +22,44 @@ theorem Equation46_termDefinableFrom_equalShape {L : NatMagmaLaw}
   (hShape : L.lhs ⬝ (fun _ ↦ Lf 0) = L.rhs ⬝ (fun _ ↦ Lf 0) := by rfl)
   (hDisjoint : L.lhs.elems.val.Disjoint L.rhs.elems := by rw [List.Disjoint]; decide +kernel)
   : Law46.TermDefinableFrom L := by
-  --There are two cases: there is at least one function application, or both sides of L are leaves.
-  cases hlhs : L.lhs
-  next x =>
-    --In this case, the law is of the form x = y. Thus, it is (equivalent to) equation 2
-    obtain ⟨y,hy⟩ : ∃ y, L.rhs = Lf y := sorry
-    have hxy : x ≠ y := sorry
-    rw [show L = Lf x ≃ Lf y from sorry]
-    clear hlhs hy hShape hDisjoint
-    apply termDefinable_of_termStructural
-    apply termStructural_of_implies
-    have : (Lf x ≃ Lf y).toFin.toNat = Law2 := by
-      -- have h₁ : (Lf x ≃ Lf y : NatMagmaLaw).elems.1 = [x,y] := by
-      --   sorry
-      -- have h₂ : Fin ((Lf x ≃ Lf y : NatMagmaLaw).elems).1.length = Fin 2 := by
-      --   rw [h₁]
-      --   simp
-      -- simp [toFin, h₁]
-      -- simp_rw [h₁]
-      sorry
-    unfold implies
-    simp_rw [← satisfies_toFin (E := Lf x ≃ Lf y)
-            , ← satisfies_toNat (E := (Lf x ≃ Lf y).toFin),
-            this]
-    exact Equation2_implies Law46
-  --Otherwise we call back to the more interesting case of a function application
   intro G M hGL
+  --The new operation ignores its second argument, and plugs its first argument into every
+  --variable of `L.lhs`.
   use ⟨fun x _ ↦ @Term.realize _ _ M.FOStructure _ (fun _ ↦ x) L.lhs.toTerm⟩
+  --Since the two sides have the same shape, they agree on every constant assignment. (This is
+  --just `hShape` pushed forward along the evaluation homomorphism.)
+  have hboth : ∀ z : G, L.lhs ⬝ (fun _ ↦ z) = L.rhs ⬝ (fun _ ↦ z) := fun z ↦ by
+    have h := congrArg (FreeMagma.evalInMagma (fun _ ↦ z)) hShape
+    rwa [FreeMagma.SubstEval, FreeMagma.SubstEval] at h
+  --The new operation is in fact constant: feeding `x` to the variables of the left side and `x'`
+  --to the (disjoint!) variables of the right side, `L` says that the two constant evaluations
+  --agree.
+  have hconst : ∀ x x' : G, L.lhs ⬝ (fun _ ↦ x) = L.lhs ⬝ (fun _ ↦ x') := by
+    intro x x'
+    let ψ : ℕ → G := fun n ↦ if n ∈ L.lhs.elems.val then x else x'
+    calc L.lhs ⬝ (fun _ ↦ x)
+        = L.lhs ⬝ ψ :=
+          (FreeMagma.evalInMagma_congr _ fun a ha ↦ if_pos ((L.lhs.elems.2.2 a).2 ha)).symm
+      _ = L.rhs ⬝ ψ := hGL ψ
+      _ = L.rhs ⬝ (fun _ ↦ x') :=
+          FreeMagma.evalInMagma_congr _ fun a ha ↦
+            if_neg fun hm ↦ hDisjoint hm ((L.rhs.elems.2.2 a).2 ha)
+      _ = L.lhs ⬝ (fun _ ↦ x') := (hboth x').symm
   constructor
+  --A constant operation satisfies law 46.
   · rw [@Law46.models_iff]
-    by_cases hG : Nonempty G
-    · suffices ∃ c, ∀ (x y : G), x ◇ y = c by
-        obtain ⟨c,h⟩ := this
-        intros x y z w
-        simp
-        sorry
-      sorry
-    · exact (not_nonempty_iff.mp hG).elim
-  · use (MagmaLanguage.lhomWithConstants _).onTerm (L.lhs.toTerm.subst fun a ↦ var 0)
+    intro x y z w
+    show @Term.realize _ _ M.FOStructure _ (fun _ ↦ x) L.lhs.toTerm
+        = @Term.realize _ _ M.FOStructure _ (fun _ ↦ z) L.lhs.toTerm
+    rw [FreeMagma.toTerm_realize, FreeMagma.toTerm_realize]
+    exact hconst x z
+  --And it is given by a term, namely `L.lhs` with every variable replaced by the first argument.
+  · use (MagmaLanguage.lhomWithConstants _).onTerm (L.lhs.toTerm.subst fun _ ↦ var 0)
     funext v
-    sorry
+    letI := M.FOStructure
+    show @Term.realize _ _ M.FOStructure _ (fun _ ↦ v 0) L.lhs.toTerm = _
+    rw [LHom.realize_onTerm, Term.realize_subst]
+    rfl
 
 /-- The constant law 46 `x ◇ y = z ◇ w` is TermDefinable from Equation 40 `x ◇ x = y ◇ y`. -/
 theorem Equation46_termDefinableFrom_Equation40 : Law46.TermDefinableFrom Law40 :=


### PR DESCRIPTION
Fill in the sorries in `Definability/Law46.lean`: the constant law is definable from any law of the form `lhs = rhs`, where those are expressions of the same shape but disjoint variable lists.