### PR TITLE
Seed reflexivity so proven results stop showing up as unknown

### DIFF
--- a/scripts/process_implications.py
+++ b/scripts/process_implications.py
@@ -80,9 +80,8 @@ def parse_proofs_file_internal(
     # probably a way to get this directly from Lean.
     for file in equations_files:
         for line in open(file):
-            if m := re.match(r"abbrev\s+(Equation\d+)\s+", line):
-                universe.add(m.group(1))
-                known_implies.add((m.group(1), m.group(1)))
+            if m := re.match(r"equation\s+(\d+)\s*:=", line):
+                universe.add(f"Equation{m.group(1)}")
 
     try:
         for line in open(file_name):
@@ -118,6 +117,7 @@ def parse_proofs_file(equations_files, file_name):
     parse_proofs_file_internal(
         universe, known_implies, known_not_implies, equations_files, file_name
     )
+    known_implies.update((eq, eq) for eq in universe)
     return universe, known_implies, known_not_implies
 
 
@@ -128,6 +128,7 @@ def parse_proofs_files(equations_files, files):
         parse_proofs_file_internal(
             universe, known_implies, known_not_implies, equations_files, file_name
         )
+    known_implies.update((eq, eq) for eq in universe)
     return universe, known_implies, known_not_implies
 
 
@@ -265,7 +266,6 @@ if __name__ == "__main__":
         print("Usage: python process_implications.py <file_name.lean>")
         exit(1)
 
-    equations_file = os.path.join(os.path.dirname(file_name), "Equations/Basic.lean")
     universe, known_implies, known_not_implies = parse_proofs_file([], file_name)
 
     all_unknown = get_unknown_implications(universe, known_implies, known_not_implies)


### PR DESCRIPTION
## The symptom

`process_implications.py <file.lean>` reports implications it has no information about, so a researcher can see what is still open. On `equational_theories/Subgraph.lean` it currently reports as unknown:

- **42 of the 52 non-implications that same file proves**, e.g. `Equation3 => Equation42`, and
- **30 equations that are not known to imply themselves**, e.g. `Equation16 => Equation16`.

So the tool asks for work that the input it just parsed had already done.

## The cause

`parse_proofs_file_internal` seeds the reflexive pairs here:

```python
if m := re.match(r"abbrev\s+(Equation\d+)\s+", line):
    universe.add(m.group(1))
    known_implies.add((m.group(1), m.group(1)))     # the only (eq, eq) source
```

No file in the repo declares equations that way any more — the syntax is `equation 9 := x = x ◇ (x ◇ y)`, via `Equations/Command.lean`. `grep -rl "abbrev Equation[0-9]" equational_theories/` returns nothing, so the branch is dead and `(eq, eq)` is never added.

That matters because `get_unknown_implications` derives negative implications by pairing `fwd_implications[a]` with `bwd_implications[b]`, both built from the transitive closure. Without `(a, a)`, an equation is missing from its own forward and backward sets, so a proven `a ↛ b` never produces the pair `(a, b)` itself — only its strict consequences. The pair falls through to the unknown set.

`parse_extracted_implications` (the `lake exe extract_implications | ...` path in the module docstring) already does the right thing with `known_implies.update((eq, eq) for eq in universe)`. This change makes the file-parsing path agree.

## The change

- Seed `(eq, eq)` over the universe in `parse_proofs_file` / `parse_proofs_files`.
- Point the equation regex at the current `equation <N> := ...` syntax so the `equations_files` parameter is not silently inert.
- Drop the `equations_file` local in `__main__`: it was computed, never passed to `parse_proofs_file`, and aimed at `Equations/Basic.lean`, which declares no equations (`grep -c '^abbrev Equation'` and the equation count there are both 0).

I deliberately did **not** start feeding all 4694 equations into the CLI path. `get_unknown_implications` materialises `universe × universe`, so that would go from ~1.8k pairs to ~22M.

## Before / after

```
$ python scripts/process_implications.py equational_theories/Subgraph.lean
before:  Found 1072 unknown implications
after:   Found  862 unknown implications

                                                   before   after
proven non-implications wrongly listed as unknown    42/52     0/52
self-implications listed as unknown                     30        0
```

The `parse_extracted_implications` path is untouched.

Note: these scripts have no CI (`lint.yml` only covers `*.lean`), which is why this went unnoticed. I have not added one here to keep this to a single concern.