### PR TITLE
Resolve the equation files relative to find_dual.py

### DIFF
--- a/scripts/find_dual.py
+++ b/scripts/find_dual.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from __future__ import annotations
+from pathlib import Path
 from typing import Optional, Set
 import re
 
@@ -180,9 +181,10 @@ def flip_top_most(node: ExprNode):
 
 
 def main():
+    equations_dir = Path(__file__).resolve().parents[1] / "equational_theories" / "Equations"
     trees = []
     for file in ["1_999", "1000_1999", "2000_2999", "3000_3999", "4000_4694"]:
-        for line in open(f"../equational_theories/Equations/Eqns{file}.lean"):
+        for line in open(equations_dir / f"Eqns{file}.lean"):
             if "equation" in line and ":=" in line:
                 equation_number = line.split("equation")[1].split()[0]
                 trees.append(


### PR DESCRIPTION
`scripts/find_dual.py` opens `../equational_theories/Equations/Eqns*.lean`, so it only works when the current directory happens to be `scripts/`. Run it the way the README links it — `python scripts/find_dual.py` from the repo root — and it dies with `FileNotFoundError` before printing anything.

Resolved from `__file__` instead, the way `explore_magma.py` and `implication_stats.py` do.

Checked by regenerating the table from the repo root: the 2305 dual pairs it prints are identical to the ones in `data/dual_equations.md` (the only diff is that file's markdown separator row).