### PR TITLE
Stop definable.py dropping the last equation

### DIFF
--- a/scripts/definable.py
+++ b/scripts/definable.py
@@ -15,7 +15,7 @@ imp_mat = np.eye(1+N_eq, dtype=np.bool)
 for imp in imps_data:
     lhs = int(imp["lhs"][len("Equation"):])
     rhs = int(imp["rhs"][len("Equation"):])
-    if lhs >= N_eq or rhs >= N_eq: #skip sporadics
+    if lhs > N_eq or rhs > N_eq: #skip sporadics
         continue
     imp_mat[lhs,rhs] = True
 

--- a/scripts/definable.py
+++ b/scripts/definable.py
@@ -7,9 +7,14 @@ with open('imps.json', 'r') as file:
 with open('./data/duals.json', 'r') as file:
     duals_data = json.load(file)
 
-N_eq=4694
+#The base set is the equations listed in data/equations.txt, one per line and
+#numbered from 1, so its length is the largest base equation number.  Read it
+#rather than hardcoding, so that adding an equation does not silently push it
+#into the "sporadic" case below.
+with open('./data/equations.txt', 'r') as file:
+    N_eq = sum(1 for line in file if line.strip())
 
-#Store the implications as (4694+1)x(4694+1) array of bools. The extra 1 is to avoid array indexing
+#Store the implications as (N_eq+1)x(N_eq+1) array of bools. The extra 1 is to avoid array indexing
 #accidents here, since all our other data is 1-indexed
 imp_mat = np.eye(1+N_eq, dtype=np.bool)
 for imp in imps_data:

--- a/scripts/find_dual.py
+++ b/scripts/find_dual.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from __future__ import annotations
+from pathlib import Path
 from typing import Optional, Set
 import re
 
@@ -180,9 +181,10 @@ def flip_top_most(node: ExprNode):
 
 
 def main():
+    equations_dir = Path(__file__).resolve().parents[1] / "equational_theories" / "Equations"
     trees = []
     for file in ["1_999", "1000_1999", "2000_2999", "3000_3999", "4000_4694"]:
-        for line in open(f"../equational_theories/Equations/Eqns{file}.lean"):
+        for line in open(equations_dir / f"Eqns{file}.lean"):
             if "equation" in line and ":=" in line:
                 equation_number = line.split("equation")[1].split()[0]
                 trees.append(


### PR DESCRIPTION
## The bug

`scripts/definable.py` allocates its relation matrices with `N_eq + 1` rows, and
the comment says why:

```python
#Store the implications as (4694+1)x(4694+1) array of bools. The extra 1 is to avoid array indexing
#accidents here, since all our other data is 1-indexed
```

So the base equations occupy indices `1 … N_eq` inclusive. The guard that skips
sporadic equations then used `>=`:

```python
if lhs >= N_eq or rhs >= N_eq: #skip sporadics
    continue
```

which throws away every implication involving `Equation4694` as well, leaving row
and column 4694 empty for the rest of the run. Every other script in `scripts/`
draws the same line inclusively — `eq_id <= 4694` in `gather_small_magmas.py`,
`eq_num >= 1 && eq_num <= 4694` in `generate_dashboard_graph_info.rb`,
`order[i] <= 4694` in `generate_equation_explorer_graph.py` — so this one was the
outlier, not the convention.

## How much it dropped

Ingestion loop run over `data/2024-11-10-edge_list.csv.zip`, the implication-graph
snapshot in the repo, keeping only the `*_true` outcomes:

```
guard '>= N_eq':  8176188 edges recorded
guard '>  N_eq':  8178280 edges recorded   (+2092)
```

2092 proved implications involving `Equation4694`, and they feed every
equivalence-class count the script prints.

End to end on a 12-equation stand-in (`data/equations.txt` with 12 lines, one
implication each way between `Equation1` and `Equation12`, plus one sporadic
`Equation9999` that must still be skipped):

```
before:  12 equivalence classes when implications are considered
after:   11 equivalence classes when implications are considered
```

Before the fix the last equation sits in a class of its own however many
implications it has; after it merges as it should, and the sporadic is still
ignored.

## Second commit

`N_eq` was hardcoded. `data/equations.txt` lists the base equations one per line,
and its length is 4694 today — the same number — so this changes nothing now, but
it means adding an equation cannot silently reclassify it as sporadic, which is
the failure mode the first commit fixes one instance of.

The script's own inputs are already read relative to the working directory
(`./data/duals.json`), so this follows that.
