### PR TITLE
Restore the find_equation_id.js CLI and module exports

### DIFF
--- a/home_page/implications/find_equation_id.js
+++ b/home_page/implications/find_equation_id.js
@@ -905,9 +905,9 @@ function main() {
     }
 }
 
-/*
-// Commented out to prevent console errors in the browser.
-// Export functions for module use
+// Export functions for module use, and run main() when invoked as a script.
+// `require` does not exist in the browser, so both checks live inside the
+// module guard; testing `require.main` outside it is what used to throw here.
 if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         Equation,
@@ -915,12 +915,11 @@ if (typeof module !== 'undefined' && module.exports) {
         processEquation,
         main
     };
-}
 
-if (require.main === module) {
-    main();
+    if (typeof require !== 'undefined' && require.main === module) {
+        main();
+    }
 }
-*/
 
 
 function findEquation() {

--- a/home_page/implications/find_equation_id.js
+++ b/home_page/implications/find_equation_id.js
@@ -65,7 +65,9 @@ class Equation {
 
     static fromId(eqId) {
         /**Construct an equation given its id.*/
-        return _equationFromId(eqId);
+        // The ids are BigInt internally; the documented entry point takes a
+        // plain integer, so coerce rather than throwing on `44 - 1n`.
+        return _equationFromId(toBigIntSafe(eqId));
     }
 
     get id() {
@@ -351,7 +353,9 @@ function* allEqs(order) {
     To generate unique equations of all orders, use
     (function*() { for (let n = 0n; ; n++) { yield* allEqs(n); } })().
     */
-        const half = order / 2n + 1n;
+    // Documented as taking a plain integer; the arithmetic below is BigInt.
+    order = toBigIntSafe(order);
+    const half = order / 2n + 1n;
     for (let lhsOrder = 0n; lhsOrder < half; lhsOrder++) {
         for (const lhsShape of allShapes(lhsOrder)) {
             for (const rhsShape of allShapes(order - lhsOrder)) {


### PR DESCRIPTION
`home_page/implications/find_equation_id.js` documents, in its own header, three ways to use it:

```
node find_equation_id.js -i
node find_equation_id.js [12, 34] "(w*u)=t*(u*x)" 4567 "*89"
eq = Equation.fromId(integer id) / allEqs(order) / eq.dual()
```

None of them worked. The export block and the `require.main === module` check were both commented out, with the note "Commented out to prevent console errors in the browser" — `require` does not exist there, so evaluating `require.main` threw. Both checks belong *inside* the `typeof module !== 'undefined'` guard, which the browser never enters; then the browser stays quiet and node gets its CLI back.

Restoring the exports surfaced a second bug: the two documented entry points immediately threw. `Equation.fromId(44)` reaches `inputEq - 1n` and `allEqs(2)` reaches `order / 2n`, and neither coerces, so a plain integer fails with "Cannot mix BigInt and other types" — the BigInt ids are an implementation detail the header does not mention. The file already carries `toBigIntSafe` for exactly this, so both now route through it.

### Evidence

The point of the port is that it agrees with `scripts/find_equation_id.py`. Now that it runs, that is checkable, and it does:

- 16 ids spread across the range (1, 2, 3, 44, 100, 387, 999, 1000, 1500, 2000, 2500, 3000, 3456, 4000, 4321, 4694) — identical output, byte for byte
- the dual form: `*44` and `*387` — identical
- equation strings in both operators: `x ◇ y = y ◇ z` and `(w*u)=t*(u*x)` — identical, both resolving to the same ids the Python gives

For the module API, `allEqs` now yields **2 + 5 + 39 + 364 + 4284 = 4694** equations over orders 0..4, which is the project's own equation count, and `Equation.fromId(4694).id` round-trips. `fromId` accepts a number, a BigInt and a numeric string.

I did not run a full 1..4694 sweep: the Python CLI is superlinear in argument count and did not finish, so the comparison above is a spread sample rather than exhaustive.

No behaviour changes for the browser — the restored block is inside the module guard, and `findEquation()` and the rest of the page code are untouched.