### PR TITLE
Fix generate_most_wanted_list.py call to parse_proofs_file

### DIFF
--- a/scripts/generate_most_wanted_list.py
+++ b/scripts/generate_most_wanted_list.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         print("Usage: python generate_most_wanted_list.py <file_name.lean>")
         exit(1)
 
-    universe, known_implies, known_not_implies = parse_proofs_file(file_name)
+    universe, known_implies, known_not_implies = parse_proofs_file([], file_name)
     known_implies = close(known_implies)
 
     ascendants = defaultdict(int)  # equation -> equations it's implied by


### PR DESCRIPTION
Picking up the neighbouring bug you spotted while reviewing #1468.

`scripts/generate_most_wanted_list.py:36` calls `parse_proofs_file(file_name)` against the two-argument signature `parse_proofs_file(equations_files, file_name)`, so the script raises `TypeError` on any invocation:

```
$ python scripts/generate_most_wanted_list.py ../equational_theories/Subgraph.lean
TypeError: parse_proofs_file() missing 1 required positional argument: 'file_name'
```

It broke in #472, which added the `equations_files` parameter and updated `generate_image.py` but not this caller. Passing the empty list, as `process_implications.py:269` already does, is the whole fix.

After it, the script runs to completion on `equational_theories/Subgraph.lean` and writes 1377 entries to `most_wanted.md`, none of them a spurious `EquationN -> EquationN` (that count was 1407 with 30 self-implications before #1468 landed).

I have left the checked-in `scripts/most_wanted.md` alone — it dates from 2024-09-26 and regenerating it would bury a one-line fix under a 1700-line diff. Happy to do it in a separate PR if you want the artifact refreshed.

This was AI-assisted.