### PR TITLE
Fix Equation321577 implication name typo

### DIFF
--- a/equational_theories/Sheffer.lean
+++ b/equational_theories/Sheffer.lean
@@ -189,7 +189,7 @@ conjecture Equation321577_implies_Equation329857 (G: Type*) [Magma G] (_ : Equat
 conjecture Equation321577_implies_Equation345169 (G: Type*) [Magma G] (_ : Equation321577 G) : Equation345169 G
 
 @[equational_result]
-conjecture Equatio321577_implies_Equation361729 (G: Type*) [Magma G] (_ : Equation321577 G) : Equation361729 G
+conjecture Equation321577_implies_Equation361729 (G: Type*) [Magma G] (_ : Equation321577 G) : Equation361729 G
 
 @[equational_result]
 conjecture Equation329857_implies_Equation321577 (G: Type*) [Magma G] (_ : Equation329857 G) : Equation321577 G


### PR DESCRIPTION
## Summary
- Rename `Equatio321577_implies_Equation361729` to `Equation321577_implies_Equation361729` (missing `n`).

## Test plan
- [ ] CI / lake build for the affected Sheffer file