### PR TITLE
fix: reuse the cached equation list in generate_eqs_list

### DIFF
--- a/scripts/generate_eqs_list.py
+++ b/scripts/generate_eqs_list.py
@@ -138,5 +138,5 @@ if __name__ == "__main__":
             )
         exit(0)
 
-    for lhs, rhs in generate_all_eqs():
+    for lhs, rhs in eqs:
         print(format_expr(lhs), "=", format_expr(rhs))


### PR DESCRIPTION
## Summary
- `generate_eqs_list.py` already builds `eqs = list(generate_all_eqs())` for the count and `--shapes` / `--lean` paths
- The default print path called `generate_all_eqs()` again, regenerating the full stream

## Test plan
- [x] Confirm `--shapes` / `--lean` already iterate `eqs`
- [x] Default path now iterates `eqs` once


Made with [Cursor](https://cursor.com)