### PR TITLE
Fix off-by-one indexing in find_powerful_theorems

### DIFF
--- a/scripts/find_powerful_theorems.py
+++ b/scripts/find_powerful_theorems.py
@@ -48,7 +48,7 @@ def preprocess_data(data):
     r = np.zeros((n, n))
     for i, row in enumerate(outcomes):
         for j, col in enumerate(row):
-            r[i - 1, j - 1] = ids[col]
+            r[i, j] = ids[col]
 
     ok = (r == 1) | (r == 3) | (r == 5) | (r == 7)
     no = (r == 0) | (r == 2) | (r == 4) | (r == 6)


### PR DESCRIPTION
`preprocess_data` in `scripts/find_powerful_theorems.py` fills the outcome matrix with

    for i, row in enumerate(outcomes):
        for j, col in enumerate(row):
            r[i - 1, j - 1] = ids[col]

but `i` and `j` already start at 0, so `outcomes[0][0]` is written to `r[-1, -1]` and the whole matrix comes out cyclically rotated by one row and one column. The `order` array that turns matrix indices back into equation numbers is not rotated, so every pair the script reports is attributed to the wrong two equations, and pairs that already have a proof are reported as unknown ones worth proving.

Reproduction, with a five-equation input where 100 → 200 and 200 → 300 are proven and everything else is unknown (saved through `--save-cache` and read back with `--load-cache`):

before

    EquationA EquationB ValueOfAImpliesB
    200 100 1
    200 300 1
    200 400 1
    200 500 1
    100 300 1

after

    EquationA EquationB ValueOfAImpliesB
    300 200 1
    300 100 1
    300 400 1
    300 500 1
    200 100 1

The old output offers 200 → 300, which is one of the two proven implications in the input; the new output only lists genuinely unknown pairs, and 100 → 200 and 200 → 300 are correctly treated as known.

I ran the script directly against synthetic `extract_implications outcomes` JSON (both the `--save-cache`/`--load-cache` path and `preprocess_data` in isolation). I did not run it against the real Lean-generated outcomes, because that needs a full Mathlib build which I could not do on this machine.