### PR TITLE
Fix two anti-implication theorems whose names disagree with their statements

### DIFF
--- a/equational_theories/ManuallyProved/Equation1701.lean
+++ b/equational_theories/ManuallyProved/Equation1701.lean
@@ -244,7 +244,7 @@ private theorem op_1701_3253_satisfies_1701 :
 
 
 @[equational_result]
-theorem Equation1701_not_implies_Equation3252 :
+theorem Equation1701_not_implies_Equation3253 :
   ∃ (G : Type) (_ : Magma G), Equation1701 G ∧ ¬ Equation3253 G := by
   let op (x : ℕ) (y : ℕ) : ℕ := op_1701_3253 x y
   let magN : Magma ℕ := ⟨fun x y ↦ op x y⟩

--- a/equational_theories/Subgraph.lean
+++ b/equational_theories/Subgraph.lean
@@ -689,8 +689,8 @@ theorem Equation43_not_implies_Equation3 : ∃ (G: Type) (_: Magma G), Equation4
   ⟨ℕ, ⟨fun x y ↦ x + y⟩, fun _ _ ↦ Nat.add_comm _ _, fun h ↦ by simpa using h 1⟩
 
 @[equational_result]
-theorem Equation43_not_implies_Equation39 : ∃ (G: Type) (_: Magma G), Equation43 G ∧ ¬ Equation3 G :=
-  ⟨ℕ, ⟨fun x y ↦ x + y⟩, fun _ _ ↦ Nat.add_comm _ _, fun h ↦ by simpa using h 1⟩
+theorem Equation43_not_implies_Equation39 : ∃ (G: Type) (_: Magma G), Equation43 G ∧ ¬ Equation39 G :=
+  ⟨ℕ, ⟨fun x y ↦ x + y⟩, fun _ _ ↦ Nat.add_comm _ _, fun h ↦ by simpa using h 0 1⟩
 
 @[equational_result]
 theorem Equation43_not_implies_Equation42 : ∃ (G: Type) (_: Magma G), Equation43 G ∧ ¬ Equation42 G :=


### PR DESCRIPTION
I compared the name of every `Equation<A>_(not_)implies_Equation<B>` declaration in `equational_theories/` against the equations that actually appear in its statement (11,263 declarations). Two disagree.

`Subgraph.Equation43_not_implies_Equation39` is a verbatim copy of `Subgraph.Equation43_not_implies_Equation3`, two declarations above it:

    theorem Equation43_not_implies_Equation39 : ∃ (G: Type) (_: Magma G), Equation43 G ∧ ¬ Equation3 G :=
      ⟨ℕ, ⟨fun x y ↦ x + y⟩, fun _ _ ↦ Nat.add_comm _ _, fun h ↦ by simpa using h 1⟩

So it re-records 43 ⇏ 3 rather than 43 ⇏ 39, and nothing in `Subgraph.lean` establishes the result its name advertises. In the checked-in `full_entries.json` this shows up as four entries for 43 ⇏ 3 and none from `Subgraph.lean` for 43 ⇏ 39; the latter comes only from `Magma2e.Facts` and `Magma6Add.Facts` in `SmallMagmas.lean`. The graph outcome for 43 → 39 is therefore already `explicit_proof_false` and does not change here, but the theorem now proves what it is named after.

The same countermodel works. (ℕ, +) is commutative, so Equation43 holds; Equation39 is `x ◇ x = y ◇ x`, and `0 ◇ 0 = 0` while `1 ◇ 0 = 1`, so `h 0 1` is contradictory.

The second one is a naming slip in the other direction: `Equation1701_not_implies_Equation3252` in `ManuallyProved/Equation1701.lean` states `Equation1701 G ∧ ¬ Equation3253 G` and is proved with the model `op_1701_3253`, so 3253 is what is refuted and the name is the wrong half. Renamed rather than restated. (1701 → 3252 is only `implicit_proof_false` in the current graph, while 1701 → 3253 is explicit — consistent with the statement being the correct half.)

I could not build Lean locally: `lake exe cache get` needs several GB of Mathlib oleans and this machine has about 5 GB free, so I did not attempt it. The scan above and the countermodel arithmetic were checked locally; the proofs themselves are only checked by CI.