### PR TITLE
State Equation514_implies_Equation2 in terms of Equation514

### DIFF
--- a/equational_theories/FreeMagmaImplications.lean
+++ b/equational_theories/FreeMagmaImplications.lean
@@ -14,9 +14,10 @@ theorem Equation37_implies_Equation2 (G : Type _) [Magma G] :
   ⟩
 
 theorem Equation514_implies_Equation2 (G : Type _) [Magma G] :
-    (∀ x y : G, x = y ◇ (y ◇ (y ◇ y))) → Equation2 G :=
+    (∀ x y : G, x = y ◇ (y ◇ (y ◇ (y ◇ y)))) → Equation2 G :=
   fun univ ↦ ExpressionEqualsAnything_implies_Equation2 G ⟨
     1,
-    Lf 0 ⋆ (Lf 0 ⋆ (Lf 0 ⋆ Lf 0)), -- The syntactic representation of y ◇ (y ◇ (y ◇ y)))
+    -- The syntactic representation of y ◇ (y ◇ (y ◇ (y ◇ y)))
+    Lf 0 ⋆ (Lf 0 ⋆ (Lf 0 ⋆ (Lf 0 ⋆ Lf 0))),
     fun k sub ↦ univ k (sub 0)
   ⟩


### PR DESCRIPTION
`Equation514_implies_Equation2` in `FreeMagmaImplications.lean` takes as its hypothesis

    ∀ x y : G, x = y ◇ (y ◇ (y ◇ y))

which is Equation76, not Equation514. Equation514 is `x = y ◇ (y ◇ (y ◇ (y ◇ y)))` — one more level of nesting. I checked both against `data/equations.txt` and by round-tripping the strings through `scripts/find_equation_id.py`, which gives 76 and 514 respectively; the numbering is the same as when the theorem was written in September 2024, so this is not numbering drift.

The dropped level looks like a transcription slip rather than a deliberate choice of law: the trailing comment on the free magma term still reads `y ◇ (y ◇ (y ◇ y)))`, carrying the unmatched closing parenthesis of the level that went missing. This restores the level in the hypothesis and in the corresponding `FreeMagma` term, so the theorem proves what its name says.

The alternative fix would be renaming the theorem to `Equation76_implies_Equation2`, which is also self-consistent; I went with the name because both it and the comment point at 514.

The comment moved onto its own line to stay under the 100-character lint limit.

Neither theorem in this file carries `@[equational_result]` (they are stated with explicit `∀` rather than `EquationN G`), so the implication graph is unaffected either way.

I could not build Lean locally — `lake exe cache get` wants several GB of Mathlib oleans and this machine has about 5 GB free — so the elaboration of the new `FreeMagma` term is checked only by CI. The term is the same shape as the one it replaces with one extra `Lf 0 ⋆ ·`, and `evalInMagma` reduces on it definitionally exactly as before.