### PR TITLE
Show the canonically equivalent equation at the top of Explorer

### DIFF
--- a/home_page/implications/script.js
+++ b/home_page/implications/script.js
@@ -346,12 +346,34 @@ function renderImplications(index) {
     const dualDisplay = (dualIndex - 1n).toString();
     selectedEquationDual.innerHTML = `(Dual equation: <a class='link' onclick="renderImplications('${dualDisplay}')">Equation${dualIndex.toString()}[${dualEq}]</a>)`;
 
+    // Lowest-numbered equivalent, shown up top when this equation is not already the
+    // canonical representative of its class (issue 1218).
+    let canonicalIndex = Number(bigIndex);
+    if (Number(bigIndex) <= equations.length - 1) {
+        const cls = equiv.find(c => c.includes(Number(bigIndex))) || [Number(bigIndex)];
+        canonicalIndex = cls[0];
+        if (canonicalIndex !== Number(bigIndex)) {
+            const canonicalEqIdTop = BigInt(canonicalIndex) + 1n;
+            selectedEquationDual.innerHTML +=
+                ` (Canonically equivalent form: <a class='link' onclick="renderImplications('${canonicalIndex}')">Equation${canonicalEqIdTop.toString()}[${equations[canonicalIndex]}]</a>)`;
+        }
+    }
+    const canonicalEqId = BigInt(canonicalIndex) + 1n;
+
     if (commentary[eqId] !== undefined) {
         showVisibility("equationCommentary");
         equationCommentary.innerHTML = commentary[eqId];
+        if (canonicalEqId !== eqId && commentary[canonicalEqId] !== undefined) {
+            equationCommentary.innerHTML +=
+                `<h2>Commentary of the canonically equivalent ${equations[canonicalIndex]}:</h2><br>${commentary[canonicalEqId]}`;
+        }
     } else if(commentary[dualIndex] !== undefined) {
         showVisibility("equationCommentary");
         equationCommentary.innerHTML = `<h2>Commentary of the dual Equation${dualIndex}[${dualEq}]:</h2> ${commentary[dualIndex]}`;
+        if (canonicalEqId !== eqId && commentary[canonicalEqId] !== undefined) {
+            equationCommentary.innerHTML +=
+                `<h2>Commentary of the canonically equivalent ${equations[canonicalIndex]}:</h2><br>${commentary[canonicalEqId]}`;
+        }
     }
 
     if (bigIndex > BigInt(equations.length - 1)) {


### PR DESCRIPTION
Refs #1218.

If the viewed equation is equivalent to a lower-numbered one, the explorer now names that representative next to the dual, and also shows the canonical form's commentary file when one exists (in addition to any commentary on the non-canonical form).


Made with [Cursor](https://cursor.com)