### PR TITLE
Add 5093, 28770 and 374794 to an All4x4 finite refutation

### DIFF
--- a/equational_theories/Generated/All4x4Tables/Refutation99.lean
+++ b/equational_theories/Generated/All4x4Tables/Refutation99.lean
@@ -20,5 +20,5 @@ def «All4x4Tables [[0,0,0],[1,1,0],[1,0,1]]» : Magma (Fin 3) where
 /-! The facts -/
 @[equational_result]
 theorem «Facts from All4x4Tables [[0,0,0],[1,1,0],[1,0,1]]» :
-  ∃ (G : Type) (_ : Magma G) (_: Finite G), Facts G [3730] [3255, 3256, 3862, 4065, 4269, 4314, 4583, 4598, 4629] :=
+  ∃ (G : Type) (_ : Magma G) (_: Finite G), Facts G [3730] [3255, 3256, 3862, 4065, 4269, 4314, 4583, 4598, 4629, 5093, 28770, 374794] :=
     ⟨Fin 3, «All4x4Tables [[0,0,0],[1,1,0],[1,0,1]]», Finite.of_fintype _, by decideFin!⟩


### PR DESCRIPTION
## Summary
- Issue #375 asked to put the extra Austin-type laws on some All4x4 `Facts` refuted lists so finite anti-implications are not left unknown.
- Equation 5105 is now Equation 5093. Equation 28393 is not in the repo; 28770 is the other Kisielewicz Austin law next to 374794.
- Direct evaluation on `[[0,0,0],[1,1,0],[1,0,1]]` shows all three fail.

## Test plan
- [x] Python magma eval: 5093, 28770, 374794 all fail on this table
- [ ] `decideFin!` in CI

Made with [Cursor](https://cursor.com)