### PR TITLE
feat: Re-enable leanchecker in CI

### DIFF
--- a/scripts/lean4_checker/run_lean4checker.sh
+++ b/scripts/lean4_checker/run_lean4checker.sh
@@ -2,16 +2,11 @@
 
 set -e
 
-# Script sourced from the following link and modified
-# https://github.com/leanprover/lean-action/blob/main/scripts/run_lean4checker.sh
-
 # Group logging using the ::group:: workflow command
 echo "::group::leanchecker Output"
 
-# https://leanprover.zulipchat.com/#narrow/channel/458659-Equational/topic/v4.2E29.20bump/near/593523380
-echo "Skipping leanchecker due to excessive memory consumption for large computations(?)"
-# echo "Checking environment with leanchecker"
-# ~/.elan/bin/lake env leanchecker equational_theories
+echo "Checking environment with leanchecker"
+LEAN_NUM_THREADS=1 ~/.elan/bin/lake env leanchecker equational_theories
 
 echo "::endgroup::"
 echo


### PR DESCRIPTION
The check has been a no-op since the v4.29 bump. Make the build single-threaded to avoid OOMs.